### PR TITLE
Refocus personal site on machine learning journal

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,46 @@
-# kaminglui.github.io
+# Ka-Ming Lui — Technical Site
+
+This repository contains a lightweight, content-driven website for Ka-Ming Lui. The single page is structured like a
+machine-learning-focused blog so research questions, working notes, and project snapshots stay easy to maintain.
+
+## Getting started
+
+Open `index.html` in your browser to preview the site locally. Styles and scripts live in the `assets/` directory.
+
+### Local preview
+
+For a live-reload free preview that mirrors production, launch a simple HTTP server from the project root:
+
+```bash
+python -m http.server 8000
+```
+
+Then visit [http://localhost:8000](http://localhost:8000) in your browser. Stop the server with <kbd>Ctrl</kbd> + <kbd>C</kbd> when you're done.
+
+### HTML validation
+
+The markup can be linted with [HTMLHint](https://htmlhint.com/):
+
+```bash
+npx htmlhint index.html
+```
+
+Some environments may require access to the public npm registry to install the tool on first run.
+
+## Highlights
+
+- Sticky navigation with theme toggle and mobile-friendly menu
+- Intro hero paired with learning tracks, machine-learning posts, project case studies, and experience timeline
+- Modular card system shared by primary content and sidebar components for consistent styling
+- Embedded LinkedIn badge that pulls profile updates automatically alongside contact CTAs
+- Light/dark theme that respects system preferences and stores the visitor's choice
+
+## Customization
+
+- Update copy and links directly in `index.html`. Sections are grouped to mirror the navigation for quick edits.
+- The learning journal entries live inside the `#posts` section. Duplicate a `.post-card` element to add new notes and
+  update the metadata inline.
+- Adjust tokens, spacing, and shared card styles in `assets/css/style.css`. Components reuse the `.card` base class so
+  visual tweaks cascade consistently.
+- `assets/js/main.js` manages navigation interactions, theme switching, and the dynamic footer year. The LinkedIn badge
+  is pulled from the hosted script—profile updates there propagate automatically.

--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -1,0 +1,617 @@
+:root {
+  --font-base: 'Inter', system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+  --font-mono: 'Fira Code', SFMono-Regular, Consolas, 'Liberation Mono', Menlo, monospace;
+  --color-bg: #f7f7f9;
+  --color-bg-alt: rgba(255, 255, 255, 0.9);
+  --color-surface: #ffffff;
+  --color-border: rgba(26, 32, 44, 0.1);
+  --color-text: #1a202c;
+  --color-muted: #4a5568;
+  --color-accent: #3b82f6;
+  --color-accent-muted: rgba(59, 130, 246, 0.12);
+  --color-code-bg: #0f172a;
+  --shadow-sm: 0 8px 24px rgba(15, 23, 42, 0.06);
+  --shadow-lg: 0 24px 60px rgba(15, 23, 42, 0.12);
+  --radius-sm: 12px;
+  --radius-lg: 20px;
+  --nav-height: 72px;
+  color-scheme: light;
+}
+
+body.theme-dark {
+  --color-bg: #0b1120;
+  --color-bg-alt: rgba(15, 23, 42, 0.94);
+  --color-surface: rgba(15, 23, 42, 0.92);
+  --color-border: rgba(148, 163, 184, 0.16);
+  --color-text: #e2e8f0;
+  --color-muted: #94a3b8;
+  --color-accent: #60a5fa;
+  --color-accent-muted: rgba(96, 165, 250, 0.22);
+  --color-code-bg: #020617;
+  color-scheme: dark;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+html {
+  scroll-behavior: smooth;
+}
+
+body {
+  margin: 0;
+  font-family: var(--font-base);
+  background: var(--color-bg);
+  color: var(--color-text);
+  line-height: 1.6;
+  transition: background 250ms ease, color 250ms ease;
+}
+
+.stack {
+  display: grid;
+  gap: 1rem;
+}
+
+a {
+  color: inherit;
+  text-decoration: none;
+}
+
+a:hover,
+a:focus-visible {
+  text-decoration: underline;
+  text-decoration-color: var(--color-accent);
+}
+
+img {
+  max-width: 100%;
+  display: block;
+}
+
+.container {
+  width: min(1120px, 92vw);
+  margin: 0 auto;
+}
+
+.site-header {
+  position: sticky;
+  top: 0;
+  z-index: 1000;
+  background: var(--color-bg-alt);
+  backdrop-filter: blur(20px);
+  box-shadow: 0 1px 0 var(--color-border);
+}
+
+.nav {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1rem;
+  height: var(--nav-height);
+}
+
+.logo {
+  font-weight: 700;
+  letter-spacing: -0.02em;
+  font-size: 1.05rem;
+}
+
+.nav-links {
+  display: flex;
+  align-items: center;
+  gap: 1.5rem;
+  list-style: none;
+  margin: 0;
+  padding: 0;
+}
+
+.nav-links a {
+  font-size: 0.95rem;
+  font-weight: 500;
+  color: var(--color-muted);
+  transition: color 150ms ease;
+}
+
+.nav-links a:hover,
+.nav-links a:focus-visible {
+  color: var(--color-accent);
+  text-decoration: none;
+}
+
+.nav-toggle {
+  display: none;
+  flex-direction: column;
+  gap: 6px;
+  background: transparent;
+  border: 1px solid var(--color-border);
+  border-radius: 10px;
+  padding: 0.5rem;
+}
+
+.nav-toggle__bar {
+  width: 22px;
+  height: 2px;
+  background: var(--color-text);
+  border-radius: 999px;
+}
+
+.theme-toggle {
+  border: 1px solid var(--color-border);
+  background: transparent;
+  border-radius: 999px;
+  padding: 0.5rem 0.7rem;
+  font-size: 1rem;
+  cursor: pointer;
+  transition: transform 150ms ease;
+}
+
+.theme-toggle:hover,
+.theme-toggle:focus-visible {
+  transform: translateY(-2px);
+}
+
+.hero {
+  padding: clamp(4rem, 6vw, 6rem) 0 clamp(3rem, 6vw, 4rem);
+}
+
+.hero__layout {
+  display: grid;
+  gap: 2.5rem;
+  align-items: start;
+  grid-template-columns: minmax(0, 2.4fr) minmax(0, 1.6fr);
+}
+
+.hero__eyebrow {
+  font-size: 0.85rem;
+  letter-spacing: 0.18em;
+  text-transform: uppercase;
+  color: var(--color-muted);
+  margin: 0 0 1rem;
+}
+
+.hero__title {
+  font-size: clamp(2.2rem, 6vw, 3.25rem);
+  line-height: 1.15;
+  letter-spacing: -0.02em;
+  margin: 0 0 1.5rem;
+}
+
+.hero__lead {
+  font-size: 1.1rem;
+  color: var(--color-muted);
+  margin: 0 0 2rem;
+}
+
+.hero__actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.75rem;
+}
+
+.hero__meta {
+  display: grid;
+  gap: 1.5rem;
+}
+
+.meta-card {
+  background: var(--color-surface);
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-lg);
+  padding: 1.5rem;
+  box-shadow: var(--shadow-sm);
+}
+
+.meta-card h2 {
+  margin: 0 0 1rem;
+  font-size: 1rem;
+}
+
+.meta-card ul {
+  margin: 0;
+  padding-left: 1.1rem;
+  color: var(--color-muted);
+}
+
+.content-grid {
+  display: grid;
+  gap: 2rem;
+  padding-bottom: clamp(4rem, 6vw, 6rem);
+  grid-template-columns: minmax(0, 2.4fr) minmax(0, 1fr);
+}
+
+.primary {
+  display: grid;
+  gap: 2rem;
+}
+
+.card {
+  background: var(--color-surface);
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-lg);
+  padding: clamp(2rem, 5vw, 2.75rem);
+  box-shadow: var(--shadow-sm);
+}
+
+.card--sidebar {
+  padding: clamp(1.5rem, 4vw, 1.75rem);
+}
+
+.card__eyebrow {
+  text-transform: uppercase;
+  letter-spacing: 0.16em;
+  font-size: 0.75rem;
+  color: var(--color-muted);
+  margin: 0 0 1rem;
+}
+
+.card__title {
+  margin: 0 0 1.25rem;
+  font-size: clamp(1.6rem, 4vw, 2.2rem);
+}
+
+.card__body p {
+  margin: 0;
+  color: var(--color-muted);
+}
+
+.card__body p + p {
+  margin-top: 1rem;
+}
+
+.card__header {
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  gap: 1rem;
+}
+
+.card__note {
+  margin: 0;
+  font-size: 0.9rem;
+  color: var(--color-muted);
+}
+
+.card p {
+  color: var(--color-muted);
+}
+
+.card p + p {
+  margin-top: 1rem;
+}
+
+.text-link {
+  font-weight: 600;
+  color: var(--color-accent);
+}
+
+.text-link:hover,
+.text-link:focus-visible {
+  text-decoration: none;
+  filter: brightness(1.1);
+}
+
+.bullet-list {
+  margin: 0;
+  padding-left: 1.2rem;
+  display: grid;
+  gap: 0.75rem;
+  color: var(--color-muted);
+}
+
+.post-list {
+  display: grid;
+  gap: 1.5rem;
+}
+
+.post-card {
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-sm);
+  padding: 1.75rem;
+  background: var(--color-bg-alt);
+  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.6);
+  transition: transform 150ms ease, box-shadow 150ms ease;
+}
+
+body.theme-dark .post-card {
+  box-shadow: inset 0 1px 0 rgba(148, 163, 184, 0.06);
+}
+
+.post-card:hover,
+.post-card:focus-within {
+  transform: translateY(-4px);
+  box-shadow: var(--shadow-lg);
+}
+
+.post-card__eyebrow {
+  font-size: 0.8rem;
+  font-family: var(--font-mono);
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--color-accent);
+  margin: 0 0 0.75rem;
+}
+
+.post-card__title {
+  margin: 0 0 0.75rem;
+  font-size: 1.3rem;
+}
+
+.post-card p {
+  margin: 0 0 0.75rem;
+  color: var(--color-muted);
+}
+
+.post-card time {
+  font-size: 0.85rem;
+  color: var(--color-muted);
+  font-family: var(--font-mono);
+}
+
+.project-list {
+  display: grid;
+  gap: 1.5rem;
+}
+
+.project-card {
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-sm);
+  padding: 1.75rem;
+  background: linear-gradient(155deg, var(--color-bg-alt), var(--color-surface));
+  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.6);
+}
+
+body.theme-dark .project-card {
+  box-shadow: inset 0 1px 0 rgba(148, 163, 184, 0.12);
+}
+
+.project-card__title {
+  margin: 0 0 0.75rem;
+  font-size: 1.2rem;
+}
+
+.project-card p {
+  margin: 0 0 0.75rem;
+  color: var(--color-muted);
+}
+
+.project-card ul {
+  margin: 0;
+  padding-left: 1.1rem;
+  color: var(--color-muted);
+  display: grid;
+  gap: 0.4rem;
+}
+
+.timeline {
+  margin: 0;
+  padding: 0;
+  list-style: none;
+  border-left: 2px solid var(--color-border);
+  display: grid;
+  gap: 1.75rem;
+}
+
+.timeline__item {
+  position: relative;
+  padding-left: 1.75rem;
+}
+
+.timeline__marker {
+  position: absolute;
+  left: -9px;
+  top: 0.2rem;
+  width: 12px;
+  height: 12px;
+  border-radius: 50%;
+  background: var(--color-bg);
+  border: 2px solid var(--color-accent);
+}
+
+.timeline__title {
+  margin: 0 0 0.5rem;
+}
+
+.timeline__role {
+  margin: 0 0 0.75rem;
+  font-size: 0.95rem;
+  color: var(--color-muted);
+}
+
+.sidebar {
+  display: grid;
+  gap: 1.5rem;
+  align-content: start;
+}
+
+.card--sidebar .card__title {
+  font-size: 1.2rem;
+  margin-bottom: 1rem;
+}
+
+.card--sidebar p {
+  margin: 0;
+  color: var(--color-muted);
+}
+
+.card--sidebar p + p {
+  margin-top: 0.75rem;
+}
+
+.card--sidebar .simple-list {
+  margin: 0;
+  padding-left: 1.1rem;
+  color: var(--color-muted);
+  display: grid;
+  gap: 0.45rem;
+}
+
+.simple-list {
+  margin: 0;
+  padding-left: 1.1rem;
+  display: grid;
+  gap: 0.45rem;
+  color: var(--color-muted);
+}
+
+.linkedin-badge {
+  margin-top: 1rem;
+}
+
+.linkedin-badge iframe {
+  width: 100% !important;
+}
+
+.button {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 0.5rem;
+  font-weight: 600;
+  border-radius: 999px;
+  padding: 0.8rem 1.4rem;
+  font-size: 0.95rem;
+  transition: transform 150ms ease, box-shadow 150ms ease;
+}
+
+.button--primary {
+  background: var(--color-accent);
+  color: #ffffff;
+  box-shadow: 0 14px 30px rgba(59, 130, 246, 0.35);
+}
+
+.button--ghost {
+  border: 1px solid var(--color-border);
+  background: transparent;
+  color: var(--color-text);
+}
+
+.button:hover,
+.button:focus-visible {
+  transform: translateY(-2px);
+}
+
+.site-footer {
+  background: var(--color-surface);
+  border-top: 1px solid var(--color-border);
+  padding: clamp(3rem, 6vw, 4.5rem) 0;
+}
+
+.footer__layout {
+  display: grid;
+  gap: 2rem;
+}
+
+.footer__layout h2 {
+  margin: 0 0 1rem;
+  font-size: clamp(1.8rem, 4vw, 2.4rem);
+}
+
+.footer__layout p {
+  margin: 0 0 1rem;
+  color: var(--color-muted);
+}
+
+.footer__actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.75rem;
+}
+
+.footer__meta {
+  font-size: 0.9rem;
+  color: var(--color-muted);
+  display: grid;
+  gap: 0.35rem;
+}
+
+.back-to-top {
+  display: block;
+  width: fit-content;
+  margin: 2rem auto 0;
+  font-size: 0.85rem;
+  font-family: var(--font-mono);
+  color: var(--color-muted);
+}
+
+.sr-only {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  border: 0;
+}
+
+@media (max-width: 960px) {
+  .hero__layout {
+    grid-template-columns: 1fr;
+  }
+
+  .hero__meta {
+    grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  }
+
+  .content-grid {
+    grid-template-columns: 1fr;
+  }
+
+  .sidebar {
+    grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  }
+}
+
+@media (max-width: 800px) {
+  .nav-links {
+    position: fixed;
+    inset: calc(var(--nav-height) + 1rem) 1rem auto;
+    flex-direction: column;
+    align-items: flex-start;
+    background: var(--color-bg-alt);
+    border: 1px solid var(--color-border);
+    border-radius: var(--radius-lg);
+    padding: 1.5rem;
+    box-shadow: var(--shadow-lg);
+    opacity: 0;
+    pointer-events: none;
+    transform: translateY(-10px);
+    transition: opacity 150ms ease, transform 150ms ease;
+  }
+
+  .nav-links[data-visible='true'] {
+    opacity: 1;
+    pointer-events: auto;
+    transform: translateY(0);
+  }
+
+  .nav-toggle {
+    display: inline-flex;
+  }
+
+  body.nav-open {
+    overflow: hidden;
+  }
+}
+
+@media (max-width: 640px) {
+  .hero {
+    padding-top: 3.5rem;
+  }
+
+  .card {
+    padding: 1.75rem;
+  }
+
+  .post-card,
+  .project-card,
+  .card--sidebar {
+    padding: 1.5rem;
+  }
+
+  .footer__actions {
+    flex-direction: column;
+    align-items: stretch;
+  }
+}

--- a/assets/js/main.js
+++ b/assets/js/main.js
@@ -1,0 +1,75 @@
+const body = document.body;
+const navToggle = document.querySelector('.nav-toggle');
+const navLinks = document.querySelector('.nav-links');
+const themeToggle = document.querySelector('.theme-toggle');
+const yearElement = document.querySelector('#year');
+
+const prefersDarkScheme = window.matchMedia('(prefers-color-scheme: dark)');
+const storedTheme = window.localStorage.getItem('theme');
+
+const setTheme = (isDark) => {
+  body.classList.toggle('theme-dark', isDark);
+  body.classList.toggle('theme-light', !isDark);
+  if (themeToggle) {
+    themeToggle.innerHTML = isDark
+      ? '<span aria-hidden="true">☀️</span>'
+      : '<span aria-hidden="true">🌙</span>';
+  }
+};
+
+if (storedTheme === 'dark' || (!storedTheme && prefersDarkScheme.matches)) {
+  setTheme(true);
+} else {
+  setTheme(false);
+}
+
+prefersDarkScheme.addEventListener('change', (event) => {
+  if (window.localStorage.getItem('theme')) return;
+  setTheme(event.matches);
+});
+
+if (navToggle) {
+  navToggle.addEventListener('click', () => {
+    const isExpanded = navToggle.getAttribute('aria-expanded') === 'true';
+    navToggle.setAttribute('aria-expanded', String(!isExpanded));
+    navLinks?.setAttribute('data-visible', String(!isExpanded));
+    body.classList.toggle('nav-open', !isExpanded);
+  });
+
+  navLinks?.addEventListener('click', (event) => {
+    if (event.target instanceof HTMLAnchorElement) {
+      navToggle.setAttribute('aria-expanded', 'false');
+      navLinks.setAttribute('data-visible', 'false');
+      body.classList.remove('nav-open');
+    }
+  });
+
+  window.addEventListener('keydown', (event) => {
+    if (event.key === 'Escape' && navToggle.getAttribute('aria-expanded') === 'true') {
+      navToggle.setAttribute('aria-expanded', 'false');
+      navLinks?.setAttribute('data-visible', 'false');
+      body.classList.remove('nav-open');
+      navToggle.focus();
+    }
+  });
+
+  window.addEventListener('resize', () => {
+    if (window.innerWidth >= 720) {
+      navToggle.setAttribute('aria-expanded', 'false');
+      navLinks?.setAttribute('data-visible', 'false');
+      body.classList.remove('nav-open');
+    }
+  });
+}
+
+if (themeToggle) {
+  themeToggle.addEventListener('click', () => {
+    const isDark = !body.classList.contains('theme-dark');
+    setTheme(isDark);
+    window.localStorage.setItem('theme', isDark ? 'dark' : 'light');
+  });
+}
+
+if (yearElement) {
+  yearElement.textContent = String(new Date().getFullYear());
+}

--- a/index.html
+++ b/index.html
@@ -1,0 +1,300 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <meta
+      name="description"
+      content="Machine learning engineering journal and technical profile for Ka-Ming Lui, Penn State M.S. student translating electrical engineering rigor into ML systems."
+    />
+    <title>Ka-Ming Lui · Machine Learning Engineer</title>
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&family=Fira+Code:wght@400;500&display=swap"
+      rel="stylesheet"
+    />
+    <link rel="stylesheet" href="assets/css/style.css" />
+  </head>
+  <body class="theme-light">
+    <header class="site-header" id="top">
+      <div class="container">
+        <nav class="nav" aria-label="Primary">
+          <a class="logo" href="#hero">Ka-Ming Lui</a>
+          <button
+            class="nav-toggle"
+            type="button"
+            aria-expanded="false"
+            aria-controls="primary-navigation"
+          >
+            <span class="nav-toggle__bar"></span>
+            <span class="nav-toggle__bar"></span>
+            <span class="nav-toggle__bar"></span>
+            <span class="sr-only">Toggle navigation</span>
+          </button>
+          <ul class="nav-links" id="primary-navigation" data-visible="false">
+            <li><a href="#about">About</a></li>
+            <li><a href="#learning">Learning</a></li>
+            <li><a href="#posts">Posts</a></li>
+            <li><a href="#projects">Projects</a></li>
+            <li><a href="#experience">Experience</a></li>
+            <li><a href="#contact">Contact</a></li>
+          </ul>
+          <button class="theme-toggle" type="button" aria-label="Toggle color theme">
+            <span aria-hidden="true">🌙</span>
+          </button>
+        </nav>
+      </div>
+    </header>
+
+    <main>
+      <section class="hero" id="hero">
+        <div class="container hero__layout">
+          <div class="hero__content">
+            <p class="hero__eyebrow">Machine learning systems · Responsible AI · Intelligent instrumentation</p>
+            <h1 class="hero__title">I build trustworthy machine learning pipelines that bridge data, hardware, and people.</h1>
+            <p class="hero__lead">
+              I'm Ka-Ming, an electrical engineer turned machine learning specialist pursuing my M.S. at Penn State.
+              I translate research questions into production-ready models, tooling, and documentation that help teams
+              learn faster and deploy confidently.
+            </p>
+            <div class="hero__actions">
+              <a class="button button--primary" href="#posts">Explore the learning journal</a>
+              <a class="button button--ghost" href="https://www.linkedin.com/in/ka-ming-lui/">LinkedIn profile</a>
+            </div>
+          </div>
+          <aside class="hero__meta" aria-label="Quick facts">
+            <article class="meta-card">
+              <h2>Currently</h2>
+              <ul>
+                <li>M.S. Electrical Engineering @ Penn State</li>
+                <li>Researching human-centered ML for instrumentation</li>
+                <li>Temple University B.S. Electrical Engineering alum</li>
+              </ul>
+            </article>
+            <article class="meta-card">
+              <h2>Focus areas</h2>
+              <ul>
+                <li>Model evaluation &amp; responsible deployment</li>
+                <li>ML Ops for sensing and embedded data</li>
+                <li>Interpretable learning for physical systems</li>
+              </ul>
+            </article>
+          </aside>
+        </div>
+      </section>
+
+      <div class="container content-grid">
+        <div class="primary">
+          <section class="card card--section" id="about">
+            <p class="card__eyebrow">About</p>
+            <h2 class="card__title">Engineering rigor meets machine learning momentum.</h2>
+            <div class="card__body stack">
+              <p>
+                My background in electrical engineering keeps me grounded in measurement science, hardware constraints,
+                and safety-critical thinking. As a master's student at Penn State, I now focus that rigor on building
+                machine learning systems that can be audited, trusted, and iterated quickly.
+              </p>
+              <p>
+                I thrive when translating domain expertise into ML-ready datasets, shaping modeling experiments, and
+                productizing the insights—whether for research collaborations, student teams, or industry partners.
+              </p>
+            </div>
+          </section>
+
+          <section class="card card--section" id="learning">
+            <p class="card__eyebrow">Learning Tracks</p>
+            <h2 class="card__title">Current questions I'm unpacking</h2>
+            <ul class="bullet-list">
+              <li>How to align evaluation metrics with real-world risk in human-in-the-loop ML systems.</li>
+              <li>Designing lightweight deployment stacks for models that serve embedded instrumentation.</li>
+              <li>Techniques for demystifying transformer internals when teaching newcomers to deep learning.</li>
+              <li>Bridging simulation data with lab measurements to bootstrap reinforcement learning policies.</li>
+            </ul>
+          </section>
+
+          <section class="card card--section" id="posts">
+            <p class="card__eyebrow">Learning Journal</p>
+            <div class="card__header">
+              <h2 class="card__title">Working notes on machine learning concepts</h2>
+              <a class="text-link" href="mailto:hello@kaminglui.com?subject=Learning%20journal%20updates">Get updates</a>
+            </div>
+            <div class="post-list">
+              <article class="post-card">
+                <p class="post-card__eyebrow">Concept Walkthrough</p>
+                <h3 class="post-card__title">Building intuition for backpropagation using circuit analogies</h3>
+                <p>
+                  Relating gradients to current flow to explain why parameter updates behave the way they do across deep
+                  networks.
+                </p>
+                <time datetime="2024-04-18">April 18, 2024</time>
+              </article>
+              <article class="post-card">
+                <p class="post-card__eyebrow">Study Notes</p>
+                <h3 class="post-card__title">From Kalman filters to transformers: a state-estimation mindset</h3>
+                <p>
+                  Mapping classic control theory tools onto attention mechanisms to highlight shared mathematical
+                  structure.
+                </p>
+                <time datetime="2024-03-02">March 2, 2024</time>
+              </article>
+              <article class="post-card">
+                <p class="post-card__eyebrow">Experiment Log</p>
+                <h3 class="post-card__title">Evaluating robustness of tinyML models under sensor drift</h3>
+                <p>
+                  A repeatable protocol for stress-testing microcontroller deployments with synthetic noise and staged
+                  recalibration.
+                </p>
+                <time datetime="2024-01-21">January 21, 2024</time>
+              </article>
+            </div>
+          </section>
+
+          <section class="card card--section" id="projects">
+            <p class="card__eyebrow">Selected Projects</p>
+            <h2 class="card__title">Hands-on work that blends ML with hardware</h2>
+            <div class="project-list">
+              <article class="project-card">
+                <h3 class="project-card__title">Edge inference for structural sensing</h3>
+                <p>
+                  Designed a pipeline that streams vibration data from embedded sensors, learns anomaly signatures, and
+                  serves alerts through a lightweight API for facilities engineers.
+                </p>
+                <ul>
+                  <li>On-device preprocessing with Rust and TensorFlow Lite</li>
+                  <li>Model monitoring dashboard built in FastAPI</li>
+                  <li>Data versioning and experiment tracking with DVC</li>
+                </ul>
+              </article>
+              <article class="project-card">
+                <h3 class="project-card__title">Responsible ML toolkit for research labs</h3>
+                <p>
+                  Built templates that guide data collection, bias checks, and documentation for student-led ML studies
+                  spanning imaging to acoustics.
+                </p>
+                <ul>
+                  <li>Reusable datasheets and model cards via Jupyter + Quarto</li>
+                  <li>Continuous integration workflows on GitHub Actions</li>
+                  <li>Interactive visualizations with Observable notebooks</li>
+                </ul>
+              </article>
+              <article class="project-card">
+                <h3 class="project-card__title">Explainable AI study group</h3>
+                <p>
+                  Facilitated a cross-disciplinary seminar dissecting interpretability papers, with weekly labs applying
+                  techniques to real sensor datasets.
+                </p>
+                <ul>
+                  <li>Comparative demos using Captum, SHAP, and LIME</li>
+                  <li>Shared repo of reproducible notebooks and slide decks</li>
+                  <li>Peer-led office hours supporting 30+ students</li>
+                </ul>
+              </article>
+            </div>
+          </section>
+
+          <section class="card card--section" id="experience">
+            <p class="card__eyebrow">Experience</p>
+            <h2 class="card__title">Academic &amp; professional journey</h2>
+            <ol class="timeline">
+              <li class="timeline__item">
+                <div class="timeline__marker" aria-hidden="true"></div>
+                <div class="timeline__content">
+                  <h3 class="timeline__title">Penn State University</h3>
+                  <p class="timeline__role">Graduate Research Assistant · 2023 — Present</p>
+                  <p>
+                    Leading machine learning initiatives for instrumentation projects, from data acquisition strategy
+                    through interpretability reviews with research partners.
+                  </p>
+                </div>
+              </li>
+              <li class="timeline__item">
+                <div class="timeline__marker" aria-hidden="true"></div>
+                <div class="timeline__content">
+                  <h3 class="timeline__title">Temple University</h3>
+                  <p class="timeline__role">B.S. Electrical Engineering · 2019 — 2023</p>
+                  <p>
+                    Graduated with honors while co-leading robotics teams and organizing study sessions on signal
+                    processing foundations for ML.
+                  </p>
+                </div>
+              </li>
+              <li class="timeline__item">
+                <div class="timeline__marker" aria-hidden="true"></div>
+                <div class="timeline__content">
+                  <h3 class="timeline__title">Industry &amp; consulting</h3>
+                  <p class="timeline__role">Embedded, data, and ML engineering · 2018 — Present</p>
+                  <p>
+                    Partnering with startups and labs to operationalize data pipelines, validate algorithms on hardware,
+                    and document results for stakeholders.
+                  </p>
+                </div>
+              </li>
+            </ol>
+          </section>
+        </div>
+
+        <aside class="sidebar">
+          <section class="card card--sidebar">
+            <h2 class="card__title">Toolkit</h2>
+            <ul class="simple-list">
+              <li>Python · PyTorch · TensorFlow</li>
+              <li>NumPy · Pandas · scikit-learn</li>
+              <li>Weights &amp; Biases · MLflow · DVC</li>
+              <li>MATLAB · C/C++ · Rust</li>
+            </ul>
+          </section>
+          <section class="card card--sidebar">
+            <h2 class="card__title">Learning cadence</h2>
+            <p>
+              Weekly writing sprints keep concepts fresh, paired with reading groups and lab demos so theory meets
+              hands-on exploration.
+            </p>
+            <p class="card__note">Reach out if you'd like to co-host a session or share datasets.</p>
+          </section>
+          <section class="card card--sidebar" aria-label="LinkedIn profile">
+            <h2 class="card__title">Live profile</h2>
+            <p class="card__note">Information below syncs directly with LinkedIn—updates there appear here automatically.</p>
+            <div class="linkedin-badge">
+              <div
+                class="LI-profile-badge"
+                data-version="v1"
+                data-size="medium"
+                data-locale="en_US"
+                data-type="vertical"
+                data-theme="dark"
+                data-vanity="ka-ming-lui"
+              >
+                <a class="LI-simple-link" href="https://www.linkedin.com/in/ka-ming-lui/">Ka-Ming Lui on LinkedIn</a>
+              </div>
+            </div>
+          </section>
+        </aside>
+      </div>
+    </main>
+
+    <footer class="site-footer" id="contact">
+      <div class="container footer__layout">
+        <div>
+          <h2>Let's teach machines responsibly together.</h2>
+          <p>
+            I'm interested in research collaborations, technical writing, and ML product partnerships that value
+            transparency and inclusive design. Share a short overview of what you're exploring and how I can help.
+          </p>
+          <div class="footer__actions">
+            <a class="button button--primary" href="mailto:hello@kaminglui.com">hello@kaminglui.com</a>
+            <a class="button button--ghost" href="https://www.linkedin.com/in/ka-ming-lui/">Connect on LinkedIn</a>
+          </div>
+        </div>
+        <div class="footer__meta">
+          <p>Based in Pennsylvania · Working remotely and on-site as needed.</p>
+          <p>&copy; <span id="year"></span> Ka-Ming Lui. Built with accessibility and performance in mind.</p>
+        </div>
+      </div>
+      <a class="back-to-top" href="#top">Back to top</a>
+    </footer>
+
+    <script src="https://platform.linkedin.com/badges/js/profile.js" async defer></script>
+    <script src="assets/js/main.js" defer></script>
+  </body>
+</html>


### PR DESCRIPTION
## Summary
- reposition the homepage copy and navigation around machine-learning learning tracks, posts, and updated experience
- introduce reusable card styling, refreshed project highlights, and a LinkedIn badge that stays synced with profile updates
- refresh the README to document the new content structure, customization workflow, and automatic LinkedIn integration

## Testing
- `npx htmlhint index.html` *(fails: npm registry access returns 403)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6910ebc8bfd48327a843ce0a46c22097)