### PR TITLE
Add navigation dropdown and ML mini game page

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -10,6 +10,10 @@
   --color-muted: #4a5568;
   --color-accent: #3b82f6;
   --color-accent-muted: rgba(59, 130, 246, 0.12);
+  --color-success: #16a34a;
+  --color-success-muted: rgba(22, 163, 74, 0.14);
+  --color-danger: #dc2626;
+  --color-danger-muted: rgba(220, 38, 38, 0.14);
   --color-code-bg: #0f172a;
   --shadow-sm: 0 8px 24px rgba(15, 23, 42, 0.06);
   --shadow-lg: 0 24px 60px rgba(15, 23, 42, 0.12);
@@ -28,6 +32,10 @@ body.theme-dark {
   --color-muted: #94a3b8;
   --color-accent: #60a5fa;
   --color-accent-muted: rgba(96, 165, 250, 0.22);
+  --color-success: #22c55e;
+  --color-success-muted: rgba(34, 197, 94, 0.22);
+  --color-danger: #f87171;
+  --color-danger-muted: rgba(248, 113, 113, 0.22);
   --color-code-bg: #020617;
   color-scheme: dark;
 }
@@ -107,6 +115,12 @@ img {
   padding: 0;
 }
 
+.nav-links > li {
+  position: relative;
+  display: flex;
+  align-items: center;
+}
+
 .nav-links a {
   font-size: 0.95rem;
   font-weight: 500;
@@ -116,6 +130,69 @@ img {
 
 .nav-links a:hover,
 .nav-links a:focus-visible {
+  color: var(--color-accent);
+  text-decoration: none;
+}
+
+.nav-dropdown-toggle {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.35rem;
+  font-size: 0.95rem;
+  font-weight: 500;
+  font-family: inherit;
+  color: var(--color-muted);
+  background: transparent;
+  border: none;
+  cursor: pointer;
+  padding: 0;
+  transition: color 150ms ease;
+}
+
+.nav-dropdown-toggle:hover,
+.nav-dropdown-toggle:focus-visible {
+  color: var(--color-accent);
+}
+
+.nav-dropdown__icon {
+  width: 0.75rem;
+  height: 0.75rem;
+  fill: currentColor;
+  transition: transform 150ms ease;
+}
+
+.nav-item--dropdown[data-open='true'] .nav-dropdown__icon {
+  transform: rotate(180deg);
+}
+
+.nav-dropdown-menu {
+  position: absolute;
+  top: calc(100% + 0.65rem);
+  left: 0;
+  min-width: 200px;
+  display: flex;
+  flex-direction: column;
+  gap: 0.35rem;
+  margin: 0;
+  padding: 0.75rem;
+  list-style: none;
+  background: var(--color-surface);
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-sm);
+  box-shadow: var(--shadow-lg);
+  z-index: 1000;
+}
+
+.nav-dropdown-menu a {
+  display: block;
+  padding: 0.35rem 0.25rem;
+  border-radius: 0.5rem;
+  color: var(--color-muted);
+}
+
+.nav-dropdown-menu a:hover,
+.nav-dropdown-menu a:focus-visible {
+  background: var(--color-accent-muted);
   color: var(--color-accent);
   text-decoration: none;
 }
@@ -618,6 +695,36 @@ body.theme-dark .project-card {
     transform: translateY(0);
   }
 
+  .nav-links > li {
+    width: 100%;
+    flex-direction: column;
+    align-items: flex-start;
+    gap: 0.5rem;
+  }
+
+  .nav-dropdown-toggle {
+    width: 100%;
+    justify-content: space-between;
+  }
+
+  .nav-dropdown-menu {
+    position: static;
+    width: 100%;
+    min-width: 0;
+    padding: 0.25rem 0 0.5rem;
+    border: none;
+    border-radius: 0;
+    box-shadow: none;
+    background: transparent;
+    gap: 0.25rem;
+  }
+
+  .nav-dropdown-menu a {
+    width: 100%;
+    padding: 0.45rem 0;
+    border-radius: 0.35rem;
+  }
+
   .nav-toggle {
     display: inline-flex;
   }
@@ -646,12 +753,184 @@ body.theme-dark .project-card {
     flex-direction: column;
     align-items: stretch;
   }
+
+  .game-hero {
+    padding-top: 2.5rem;
+  }
+
+  .game-status {
+    flex-direction: column;
+    align-items: flex-start;
+    gap: 0.4rem;
+  }
+
+  .game-options {
+    grid-template-columns: 1fr;
+  }
 }
 
 .nav-actions {
   display: flex;
   align-items: center;
   gap: 0.75rem;
+}
+
+.game-main {
+  padding-bottom: clamp(3rem, 6vw, 5rem);
+}
+
+.game-hero {
+  padding: clamp(3rem, 6vw, 5rem) 0 clamp(2rem, 6vw, 3rem);
+  text-align: center;
+}
+
+.game-hero__inner {
+  width: min(720px, 92vw);
+  margin: 0 auto;
+  display: grid;
+  gap: 1.25rem;
+}
+
+.game-hero__eyebrow {
+  font-size: 0.85rem;
+  letter-spacing: 0.18em;
+  text-transform: uppercase;
+  color: var(--color-muted);
+  margin: 0;
+}
+
+.game-hero__title {
+  margin: 0;
+  font-size: clamp(2.2rem, 6vw, 3rem);
+  letter-spacing: -0.03em;
+}
+
+.game-hero__lead {
+  margin: 0;
+  font-size: 1.1rem;
+  color: var(--color-muted);
+}
+
+.game-section {
+  padding: 0 0 clamp(4rem, 7vw, 5rem);
+}
+
+.game-card {
+  max-width: 760px;
+  margin: 0 auto;
+  display: grid;
+  gap: 1.5rem;
+}
+
+.game-intro {
+  margin: 0;
+  color: var(--color-muted);
+}
+
+.game-status {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  font-family: var(--font-mono);
+  font-size: 0.9rem;
+  color: var(--color-muted);
+}
+
+.game-question {
+  margin: 0;
+  font-size: clamp(1.3rem, 3vw, 1.6rem);
+  font-weight: 600;
+  letter-spacing: -0.01em;
+}
+
+.game-options {
+  display: grid;
+  gap: 0.75rem;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+}
+
+.game-option {
+  display: flex;
+  align-items: flex-start;
+  gap: 0.75rem;
+  text-align: left;
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-sm);
+  background: transparent;
+  padding: 0.9rem 1rem;
+  font-size: 1rem;
+  font-family: inherit;
+  color: inherit;
+  cursor: pointer;
+  transition: border-color 150ms ease, box-shadow 150ms ease, transform 150ms ease;
+}
+
+.game-option:hover,
+.game-option:focus-visible {
+  border-color: var(--color-accent);
+  box-shadow: 0 10px 24px rgba(59, 130, 246, 0.18);
+  transform: translateY(-2px);
+}
+
+.game-option[disabled] {
+  cursor: not-allowed;
+  opacity: 0.85;
+  box-shadow: none;
+  transform: none;
+}
+
+.game-option--correct {
+  border-color: var(--color-success);
+  background: var(--color-success-muted);
+  color: var(--color-success);
+}
+
+.game-option--incorrect {
+  border-color: var(--color-danger);
+  background: var(--color-danger-muted);
+  color: var(--color-danger);
+}
+
+.game-feedback {
+  min-height: 1.5rem;
+  font-weight: 600;
+}
+
+.game-feedback--correct {
+  color: var(--color-success);
+}
+
+.game-feedback--incorrect {
+  color: var(--color-danger);
+}
+
+.game-fact {
+  margin: 0;
+  padding: 1rem 1.25rem;
+  border-left: 4px solid var(--color-accent);
+  border-radius: var(--radius-sm);
+  background: var(--color-accent-muted);
+  color: var(--color-muted);
+}
+
+.game-actions {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+}
+
+.game-summary {
+  font-size: 1.1rem;
+  font-weight: 600;
+  margin: 0;
+}
+
+.game-next {
+  align-self: flex-start;
+}
+
+.game-restart[hidden] {
+  display: none;
 }
 
 .manage-trigger,

--- a/assets/js/game.js
+++ b/assets/js/game.js
@@ -1,0 +1,416 @@
+const body = document.body;
+const navToggle = document.querySelector('.nav-toggle');
+const navLinks = document.querySelector('.nav-links');
+const sectionDropdownToggle = document.querySelector('.nav-dropdown-toggle');
+const sectionDropdownMenu = document.getElementById('section-menu');
+const sectionDropdownWrapper =
+  sectionDropdownToggle instanceof HTMLElement
+    ? sectionDropdownToggle.closest('.nav-item--dropdown')
+    : null;
+const themeToggle = document.querySelector('.theme-toggle');
+const yearElement = document.getElementById('year');
+const backToTopLink = document.querySelector('.back-to-top');
+
+const prefersReducedMotion =
+  typeof window !== 'undefined' && typeof window.matchMedia === 'function'
+    ? window.matchMedia('(prefers-reduced-motion: reduce)')
+    : null;
+
+function setTheme(isDark) {
+  body.classList.toggle('theme-dark', isDark);
+  body.classList.toggle('theme-light', !isDark);
+  if (themeToggle) {
+    themeToggle.innerHTML = isDark ? '<span aria-hidden="true">☀️</span>' : '<span aria-hidden="true">🌙</span>';
+  }
+}
+
+function setupTheme() {
+  if (!themeToggle) return;
+  const prefersDarkScheme = window.matchMedia('(prefers-color-scheme: dark)');
+  const storedTheme = window.localStorage.getItem('theme');
+
+  if (storedTheme === 'dark' || (!storedTheme && prefersDarkScheme.matches)) {
+    setTheme(true);
+  } else {
+    setTheme(false);
+  }
+
+  prefersDarkScheme.addEventListener('change', (event) => {
+    if (window.localStorage.getItem('theme')) return;
+    setTheme(event.matches);
+  });
+
+  themeToggle.addEventListener('click', () => {
+    const isDark = !body.classList.contains('theme-dark');
+    setTheme(isDark);
+    window.localStorage.setItem('theme', isDark ? 'dark' : 'light');
+  });
+}
+
+function setupNav() {
+  const closeDropdown = () => {
+    if (sectionDropdownToggle) {
+      sectionDropdownToggle.setAttribute('aria-expanded', 'false');
+    }
+    if (sectionDropdownMenu) {
+      sectionDropdownMenu.hidden = true;
+    }
+    sectionDropdownWrapper?.setAttribute('data-open', 'false');
+  };
+
+  const openDropdown = () => {
+    if (sectionDropdownToggle) {
+      sectionDropdownToggle.setAttribute('aria-expanded', 'true');
+    }
+    if (sectionDropdownMenu) {
+      sectionDropdownMenu.hidden = false;
+    }
+    sectionDropdownWrapper?.setAttribute('data-open', 'true');
+  };
+
+  if (sectionDropdownToggle && sectionDropdownMenu) {
+    closeDropdown();
+
+    sectionDropdownToggle.addEventListener('click', (event) => {
+      event.stopPropagation();
+      const isExpanded = sectionDropdownToggle.getAttribute('aria-expanded') === 'true';
+      if (isExpanded) {
+        closeDropdown();
+      } else {
+        openDropdown();
+      }
+    });
+
+    sectionDropdownToggle.addEventListener('keydown', (event) => {
+      if (event.key === 'ArrowDown') {
+        event.preventDefault();
+        if (sectionDropdownToggle.getAttribute('aria-expanded') !== 'true') {
+          openDropdown();
+        }
+        const firstLink = sectionDropdownMenu.querySelector('a');
+        if (firstLink instanceof HTMLElement) {
+          firstLink.focus();
+        }
+      } else if (event.key === 'Escape') {
+        closeDropdown();
+      }
+    });
+
+    sectionDropdownMenu.addEventListener('click', (event) => {
+      if (event.target instanceof HTMLAnchorElement) {
+        closeDropdown();
+      }
+    });
+
+    sectionDropdownMenu.addEventListener('keydown', (event) => {
+      if (event.key === 'Escape') {
+        event.stopPropagation();
+        closeDropdown();
+        sectionDropdownToggle.focus();
+      }
+    });
+
+    document.addEventListener('click', (event) => {
+      if (sectionDropdownWrapper && !sectionDropdownWrapper.contains(event.target)) {
+        closeDropdown();
+      }
+    });
+
+    document.addEventListener('keydown', (event) => {
+      if (event.key === 'Escape') {
+        closeDropdown();
+      }
+    });
+  }
+
+  if (navToggle) {
+    navToggle.addEventListener('click', () => {
+      const isExpanded = navToggle.getAttribute('aria-expanded') === 'true';
+      closeDropdown();
+      navToggle.setAttribute('aria-expanded', String(!isExpanded));
+      navLinks?.setAttribute('data-visible', String(!isExpanded));
+      body.classList.toggle('nav-open', !isExpanded);
+    });
+
+    window.addEventListener('keydown', (event) => {
+      if (event.key === 'Escape' && navToggle.getAttribute('aria-expanded') === 'true') {
+        navToggle.setAttribute('aria-expanded', 'false');
+        navLinks?.setAttribute('data-visible', 'false');
+        body.classList.remove('nav-open');
+        closeDropdown();
+        navToggle.focus();
+      }
+    });
+
+    window.addEventListener('resize', () => {
+      if (window.innerWidth >= 720) {
+        navToggle.setAttribute('aria-expanded', 'false');
+        navLinks?.setAttribute('data-visible', 'false');
+        body.classList.remove('nav-open');
+        closeDropdown();
+      }
+    });
+  }
+
+  navLinks?.addEventListener('click', (event) => {
+    if (event.target instanceof HTMLAnchorElement) {
+      navToggle?.setAttribute('aria-expanded', 'false');
+      navLinks.setAttribute('data-visible', 'false');
+      body.classList.remove('nav-open');
+      closeDropdown();
+    }
+  });
+}
+
+function setupBackToTop() {
+  if (!backToTopLink) return;
+
+  backToTopLink.addEventListener('click', (event) => {
+    event.preventDefault();
+
+    const behavior = prefersReducedMotion?.matches ? 'auto' : 'smooth';
+    const scrollTarget =
+      document.scrollingElement || document.documentElement || document.body || window;
+    const scrollOptions = { top: 0, left: 0, behavior };
+
+    try {
+      if (scrollTarget && typeof scrollTarget.scrollTo === 'function') {
+        scrollTarget.scrollTo(scrollOptions);
+      } else if (typeof window.scrollTo === 'function') {
+        window.scrollTo(scrollOptions);
+      }
+    } catch (error) {
+      window.scrollTo(0, 0);
+    }
+  });
+}
+
+function shuffle(list) {
+  const copy = [...list];
+  for (let i = copy.length - 1; i > 0; i -= 1) {
+    const j = Math.floor(Math.random() * (i + 1));
+    [copy[i], copy[j]] = [copy[j], copy[i]];
+  }
+  return copy;
+}
+
+function setupGame() {
+  const progressEl = document.querySelector('[data-game-progress]');
+  const scoreEl = document.querySelector('[data-game-score]');
+  const questionEl = document.querySelector('[data-game-question]');
+  const optionsContainer = document.querySelector('[data-game-options]');
+  const feedbackEl = document.querySelector('[data-game-feedback]');
+  const factEl = document.querySelector('[data-game-fact]');
+  const nextButton = document.querySelector('[data-game-next]');
+  const restartButton = document.querySelector('[data-game-restart]');
+  const summaryEl = document.querySelector('[data-game-summary]');
+
+  if (
+    !progressEl ||
+    !scoreEl ||
+    !questionEl ||
+    !optionsContainer ||
+    !feedbackEl ||
+    !factEl ||
+    !nextButton ||
+    !restartButton ||
+    !summaryEl
+  ) {
+    return;
+  }
+
+  const challenges = [
+    {
+      prompt:
+        'You have thousands of handwritten digit images and want a strong baseline for recognizing each numeral automatically.',
+      options: ['Convolutional neural network', 'Decision tree classifier', 'K-means clustering'],
+      answer: 0,
+      insight:
+        'Convolutional neural networks capture spatial hierarchies in pixel grids, making them a go-to choice for vision tasks like digit recognition.',
+      tip: 'Pair convolution and pooling layers to learn rich features before the final classifier layer.'
+    },
+    {
+      prompt:
+        'A product team wants to understand the key drivers of housing prices from tabular data with many nonlinear relationships.',
+      options: ['Gradient boosting regressor', 'Logistic regression', 'Apriori association mining'],
+      answer: 0,
+      insight:
+        'Gradient boosting ensembles handle nonlinear interactions and deliver strong performance on structured regression problems.',
+      tip: 'Tune the learning rate and number of trees to balance accuracy with generalization.'
+    },
+    {
+      prompt:
+        'You are curating thousands of unlabeled news articles and need to automatically group them by topic for editors.',
+      options: ['Latent Dirichlet Allocation', 'Support vector machine', 'Linear regression'],
+      answer: 0,
+      insight:
+        'Latent Dirichlet Allocation discovers topic mixtures in large text corpora without labeled examples, perfect for organizing articles.',
+      tip: 'Experiment with the number of topics to find a balance between specificity and interpretability.'
+    },
+    {
+      prompt:
+        'Site reliability engineers want early warnings when telemetry shows unusual behavior across hundreds of microservices.',
+      options: ['Autoencoder anomaly detector', 'Naive Bayes classifier', 'Principal component regression'],
+      answer: 0,
+      insight:
+        'Training an autoencoder on healthy data lets you flag anomalies when reconstruction error spikes on new telemetry.',
+      tip: 'Track the reconstruction loss distribution to set dynamic alert thresholds.'
+    },
+    {
+      prompt:
+        'A streaming platform recommends new movies based on what similar viewers enjoyed and the ratings they left.',
+      options: ['Matrix factorization recommender', 'Agglomerative clustering', 'Random forest classifier'],
+      answer: 0,
+      insight:
+        'Matrix factorization decomposes the user–item ratings matrix to uncover shared preferences that drive recommendations.',
+      tip: 'Regularize latent factors to avoid overfitting to a handful of prolific users.'
+    }
+  ];
+
+  let rounds = shuffle(challenges);
+  let currentIndex = 0;
+  let score = 0;
+  let answered = false;
+
+  function updateStatus() {
+    progressEl.textContent = `Round ${Math.min(currentIndex + 1, rounds.length)} of ${rounds.length}`;
+    scoreEl.textContent = `Score: ${score}`;
+  }
+
+  function resetFeedback() {
+    feedbackEl.textContent = '';
+    feedbackEl.classList.remove('game-feedback--correct', 'game-feedback--incorrect');
+    factEl.textContent = '';
+    factEl.hidden = true;
+    nextButton.disabled = true;
+    summaryEl.hidden = true;
+  }
+
+  function renderChallenge() {
+    const challenge = rounds[currentIndex];
+    questionEl.textContent = challenge.prompt;
+    optionsContainer.innerHTML = '';
+    challenge.options.forEach((option, index) => {
+      const button = document.createElement('button');
+      button.type = 'button';
+      button.className = 'game-option';
+      button.dataset.optionIndex = String(index);
+      button.textContent = option;
+      button.addEventListener('click', handleOptionSelect, { once: false });
+      optionsContainer.appendChild(button);
+    });
+    answered = false;
+    resetFeedback();
+    updateStatus();
+    nextButton.textContent = currentIndex === rounds.length - 1 ? 'See results' : 'Next challenge';
+  }
+
+  function handleOptionSelect(event) {
+    if (!(event.currentTarget instanceof HTMLButtonElement) || answered) {
+      return;
+    }
+
+    const button = event.currentTarget;
+    const selectedIndex = Number(button.dataset.optionIndex ?? '-1');
+    const challenge = rounds[currentIndex];
+    const isCorrect = selectedIndex === challenge.answer;
+    const optionButtons = Array.from(optionsContainer.querySelectorAll('button'));
+
+    optionButtons.forEach((optionButton, index) => {
+      optionButton.disabled = true;
+      if (index === challenge.answer) {
+        optionButton.classList.add('game-option--correct');
+      }
+      if (index === selectedIndex && !isCorrect) {
+        optionButton.classList.add('game-option--incorrect');
+      }
+    });
+
+    if (isCorrect) {
+      score += 1;
+      feedbackEl.textContent = `Correct! ${challenge.insight}`;
+      feedbackEl.classList.add('game-feedback--correct');
+    } else {
+      feedbackEl.textContent = `Not quite. ${challenge.insight}`;
+      feedbackEl.classList.add('game-feedback--incorrect');
+    }
+
+    if (challenge.tip) {
+      factEl.textContent = challenge.tip;
+      factEl.hidden = false;
+    }
+
+    answered = true;
+    nextButton.disabled = false;
+    updateStatus();
+    nextButton.focus();
+  }
+
+  function showSummary() {
+    progressEl.textContent = 'Summary';
+    scoreEl.textContent = `Final score: ${score} / ${rounds.length}`;
+    questionEl.textContent = 'Nice work!';
+    optionsContainer.innerHTML = '';
+    resetFeedback();
+    feedbackEl.textContent = '';
+
+    const perfect = score === rounds.length;
+    const strong = score >= Math.ceil(rounds.length * 0.6);
+    let message = `You matched ${score} out of ${rounds.length} scenarios.`;
+    if (perfect) {
+      message += ' Flawless instincts!';
+    } else if (strong) {
+      message += ' Solid ML intuition—can you hit a perfect score next time?';
+    } else {
+      message += ' Keep experimenting and try again to improve your mental model toolbox.';
+    }
+
+    summaryEl.hidden = false;
+    summaryEl.textContent = message;
+    nextButton.hidden = true;
+    restartButton.hidden = false;
+    restartButton.focus();
+  }
+
+  function handleNext() {
+    if (!answered) return;
+    if (currentIndex === rounds.length - 1) {
+      showSummary();
+      return;
+    }
+    currentIndex += 1;
+    renderChallenge();
+  }
+
+  function startGame() {
+    rounds = shuffle(challenges);
+    currentIndex = 0;
+    score = 0;
+    summaryEl.hidden = true;
+    nextButton.hidden = false;
+    restartButton.hidden = true;
+    nextButton.disabled = true;
+    nextButton.textContent = 'Next challenge';
+    renderChallenge();
+  }
+
+  nextButton.addEventListener('click', handleNext);
+  restartButton.addEventListener('click', () => {
+    startGame();
+    const firstOption = optionsContainer.querySelector('button');
+    if (firstOption instanceof HTMLElement) {
+      firstOption.focus();
+    }
+  });
+
+  startGame();
+}
+
+if (yearElement) {
+  yearElement.textContent = String(new Date().getFullYear());
+}
+
+setupNav();
+setupTheme();
+setupBackToTop();
+setupGame();

--- a/assets/js/main.js
+++ b/assets/js/main.js
@@ -111,6 +111,12 @@ function formatTitleCase(text) {
 const body = document.body;
 const navToggle = document.querySelector('.nav-toggle');
 const navLinks = document.querySelector('.nav-links');
+const sectionDropdownToggle = document.querySelector('.nav-dropdown-toggle');
+const sectionDropdownMenu = document.getElementById('section-menu');
+const sectionDropdownWrapper =
+  sectionDropdownToggle instanceof HTMLElement
+    ? sectionDropdownToggle.closest('.nav-item--dropdown')
+    : null;
 const themeToggle = document.querySelector('.theme-toggle');
 const yearElement = document.querySelector('#year');
 const editToggle = document.querySelector('.edit-toggle');
@@ -643,36 +649,116 @@ function renderAll() {
 }
 
 function setupNav() {
-  if (!navToggle) return;
-  navToggle.addEventListener('click', () => {
-    const isExpanded = navToggle.getAttribute('aria-expanded') === 'true';
-    navToggle.setAttribute('aria-expanded', String(!isExpanded));
-    navLinks?.setAttribute('data-visible', String(!isExpanded));
-    body.classList.toggle('nav-open', !isExpanded);
-  });
+  const closeDropdown = () => {
+    if (sectionDropdownToggle) {
+      sectionDropdownToggle.setAttribute('aria-expanded', 'false');
+    }
+    if (sectionDropdownMenu) {
+      sectionDropdownMenu.hidden = true;
+    }
+    sectionDropdownWrapper?.setAttribute('data-open', 'false');
+  };
+
+  const openDropdown = () => {
+    if (sectionDropdownToggle) {
+      sectionDropdownToggle.setAttribute('aria-expanded', 'true');
+    }
+    if (sectionDropdownMenu) {
+      sectionDropdownMenu.hidden = false;
+    }
+    sectionDropdownWrapper?.setAttribute('data-open', 'true');
+  };
+
+  if (sectionDropdownToggle && sectionDropdownMenu) {
+    closeDropdown();
+
+    sectionDropdownToggle.addEventListener('click', (event) => {
+      event.stopPropagation();
+      const isExpanded = sectionDropdownToggle.getAttribute('aria-expanded') === 'true';
+      if (isExpanded) {
+        closeDropdown();
+      } else {
+        openDropdown();
+      }
+    });
+
+    sectionDropdownToggle.addEventListener('keydown', (event) => {
+      if (event.key === 'ArrowDown') {
+        event.preventDefault();
+        if (sectionDropdownToggle.getAttribute('aria-expanded') !== 'true') {
+          openDropdown();
+        }
+        const firstLink = sectionDropdownMenu.querySelector('a');
+        if (firstLink instanceof HTMLElement) {
+          firstLink.focus();
+        }
+      } else if (event.key === 'Escape') {
+        closeDropdown();
+      }
+    });
+
+    sectionDropdownMenu.addEventListener('click', (event) => {
+      if (event.target instanceof HTMLAnchorElement) {
+        closeDropdown();
+      }
+    });
+
+    sectionDropdownMenu.addEventListener('keydown', (event) => {
+      if (event.key === 'Escape') {
+        event.stopPropagation();
+        closeDropdown();
+        sectionDropdownToggle.focus();
+      }
+    });
+
+    document.addEventListener('click', (event) => {
+      if (sectionDropdownWrapper && !sectionDropdownWrapper.contains(event.target)) {
+        closeDropdown();
+      }
+    });
+
+    document.addEventListener('keydown', (event) => {
+      if (event.key === 'Escape') {
+        closeDropdown();
+      }
+    });
+  }
+
+  if (navToggle) {
+    navToggle.addEventListener('click', () => {
+      const isExpanded = navToggle.getAttribute('aria-expanded') === 'true';
+      closeDropdown();
+      navToggle.setAttribute('aria-expanded', String(!isExpanded));
+      navLinks?.setAttribute('data-visible', String(!isExpanded));
+      body.classList.toggle('nav-open', !isExpanded);
+    });
+
+    window.addEventListener('keydown', (event) => {
+      if (event.key === 'Escape' && navToggle.getAttribute('aria-expanded') === 'true') {
+        navToggle.setAttribute('aria-expanded', 'false');
+        navLinks?.setAttribute('data-visible', 'false');
+        body.classList.remove('nav-open');
+        closeDropdown();
+        navToggle.focus();
+      }
+    });
+
+    window.addEventListener('resize', () => {
+      if (window.innerWidth >= 720) {
+        navToggle.setAttribute('aria-expanded', 'false');
+        navLinks?.setAttribute('data-visible', 'false');
+        body.classList.remove('nav-open');
+        closeDropdown();
+      }
+    });
+  }
 
   navLinks?.addEventListener('click', (event) => {
     if (event.target instanceof HTMLAnchorElement) {
-      navToggle.setAttribute('aria-expanded', 'false');
+      navToggle?.setAttribute('aria-expanded', 'false');
       navLinks.setAttribute('data-visible', 'false');
       body.classList.remove('nav-open');
-    }
-  });
-
-  window.addEventListener('keydown', (event) => {
-    if (event.key === 'Escape' && navToggle.getAttribute('aria-expanded') === 'true') {
-      navToggle.setAttribute('aria-expanded', 'false');
-      navLinks?.setAttribute('data-visible', 'false');
-      body.classList.remove('nav-open');
-      navToggle.focus();
-    }
-  });
-
-  window.addEventListener('resize', () => {
-    if (window.innerWidth >= 720) {
-      navToggle.setAttribute('aria-expanded', 'false');
-      navLinks?.setAttribute('data-visible', 'false');
-      body.classList.remove('nav-open');
+      closeDropdown();
     }
   });
 }

--- a/index.html
+++ b/index.html
@@ -33,13 +33,34 @@
             <span class="sr-only">Toggle navigation</span>
           </button>
           <ul class="nav-links" id="primary-navigation" data-visible="false">
-            <li><a href="#about">About</a></li>
-            <li><a href="#learning">Learning</a></li>
-            <li><a href="#posts">Posts</a></li>
-            <li><a href="#projects">Projects</a></li>
-            <li><a href="#experience">Experience</a></li>
-            <li><a href="#education">Education</a></li>
-            <li><a href="#contact">Contact</a></li>
+            <li class="nav-item nav-item--dropdown">
+              <button
+                class="nav-dropdown-toggle"
+                type="button"
+                aria-expanded="false"
+                aria-controls="section-menu"
+              >
+                Sections
+                <svg
+                  class="nav-dropdown__icon"
+                  aria-hidden="true"
+                  focusable="false"
+                  viewBox="0 0 12 12"
+                >
+                  <path d="M2.47 4.47a.75.75 0 0 1 1.06 0L6 6.94l2.47-2.47a.75.75 0 0 1 1.06 1.06l-3 3a.75.75 0 0 1-1.06 0l-3-3a.75.75 0 0 1 0-1.06Z" />
+                </svg>
+              </button>
+              <ul class="nav-dropdown-menu" id="section-menu" hidden>
+                <li><a href="#about">About</a></li>
+                <li><a href="#learning">Learning</a></li>
+                <li><a href="#posts">Posts</a></li>
+                <li><a href="#projects">Projects</a></li>
+                <li><a href="#experience">Experience</a></li>
+                <li><a href="#education">Education</a></li>
+                <li><a href="#contact">Contact</a></li>
+              </ul>
+            </li>
+            <li><a href="ml-game.html">ML Mini Game</a></li>
           </ul>
           <div class="nav-actions">
             <button class="edit-toggle" type="button" aria-pressed="false" hidden>Edit mode</button>

--- a/ml-game.html
+++ b/ml-game.html
@@ -1,0 +1,124 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <meta name="description" content="Play a machine learning themed mini game on Ka Ming Lui's site." />
+    <title>Model Match Mini Game · Ka Ming Lui</title>
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&family=Fira+Code:wght@400;500&display=swap"
+      rel="stylesheet"
+    />
+    <link rel="stylesheet" href="assets/css/style.css" />
+  </head>
+  <body class="theme-light">
+    <header class="site-header" id="top">
+      <div class="container">
+        <nav class="nav" aria-label="Primary">
+          <a class="logo" href="index.html#hero">Ka Ming Lui</a>
+          <button class="nav-toggle" type="button" aria-expanded="false" aria-controls="primary-navigation">
+            <span class="nav-toggle__bar"></span>
+            <span class="nav-toggle__bar"></span>
+            <span class="nav-toggle__bar"></span>
+            <span class="sr-only">Toggle navigation</span>
+          </button>
+          <ul class="nav-links" id="primary-navigation" data-visible="false">
+            <li class="nav-item nav-item--dropdown">
+              <button class="nav-dropdown-toggle" type="button" aria-expanded="false" aria-controls="section-menu">
+                Sections
+                <svg class="nav-dropdown__icon" aria-hidden="true" focusable="false" viewBox="0 0 12 12">
+                  <path d="M2.47 4.47a.75.75 0 0 1 1.06 0L6 6.94l2.47-2.47a.75.75 0 0 1 1.06 1.06l-3 3a.75.75 0 0 1-1.06 0l-3-3a.75.75 0 0 1 0-1.06Z" />
+                </svg>
+              </button>
+              <ul class="nav-dropdown-menu" id="section-menu" hidden>
+                <li><a href="index.html#about">About</a></li>
+                <li><a href="index.html#learning">Learning</a></li>
+                <li><a href="index.html#posts">Posts</a></li>
+                <li><a href="index.html#projects">Projects</a></li>
+                <li><a href="index.html#experience">Experience</a></li>
+                <li><a href="index.html#education">Education</a></li>
+                <li><a href="index.html#contact">Contact</a></li>
+              </ul>
+            </li>
+            <li><a href="ml-game.html" aria-current="page">ML Mini Game</a></li>
+          </ul>
+          <div class="nav-actions">
+            <button class="theme-toggle" type="button" aria-label="Toggle color theme">
+              <span aria-hidden="true">🌙</span>
+            </button>
+          </div>
+        </nav>
+      </div>
+    </header>
+
+    <main class="game-main">
+      <section class="game-hero">
+        <div class="container">
+          <div class="game-hero__inner">
+            <p class="game-hero__eyebrow">Playground</p>
+            <h1 class="game-hero__title">Model Match Mini Game</h1>
+            <p class="game-hero__lead">
+              Put your machine learning intuition to the test. Choose the algorithm that best fits each scenario and see how
+              many matches you can get in a row.
+            </p>
+          </div>
+        </div>
+      </section>
+
+      <section class="game-section" aria-labelledby="game-title">
+        <div class="container">
+          <article class="card game-card" data-game-card>
+            <header>
+              <h2 class="card__title" id="game-title">Match the model to the challenge</h2>
+              <p class="game-intro">
+                Read each challenge description and pick the approach you would try first. Every correct guess earns a point,
+                and you can replay to chase a perfect score.
+              </p>
+            </header>
+            <div class="game-status">
+              <span data-game-progress>Round 1 of 5</span>
+              <span data-game-score>Score: 0</span>
+            </div>
+            <h3 class="game-question" data-game-question></h3>
+            <div class="game-options" data-game-options role="group" aria-live="polite"></div>
+            <p class="game-feedback" data-game-feedback aria-live="polite"></p>
+            <p class="game-fact" data-game-fact hidden></p>
+            <div class="game-actions">
+              <button class="button button--primary game-next" type="button" data-game-next disabled>
+                Next challenge
+              </button>
+              <button class="button button--ghost game-restart" type="button" data-game-restart hidden>
+                Play again
+              </button>
+            </div>
+            <p class="game-summary" data-game-summary hidden></p>
+          </article>
+        </div>
+      </section>
+    </main>
+
+    <footer class="site-footer">
+      <div class="container footer__layout">
+        <div>
+          <h2>Ready for more machine learning stories?</h2>
+          <p>
+            Head back to the main site to explore projects, journal entries, and the learning roadmap behind this mini game.
+          </p>
+          <div class="footer__actions">
+            <a class="button button--primary" href="index.html#projects">View projects</a>
+            <a class="button button--ghost" href="index.html#contact">Get in touch</a>
+          </div>
+        </div>
+        <div class="footer__meta">
+          <p>Enjoyed the challenge? Share it with fellow ML explorers.</p>
+          <p>&copy; <span id="year"></span> Ka Ming Lui. Built with accessibility and performance in mind.</p>
+        </div>
+      </div>
+      <a class="back-to-top" href="#top">Back to top</a>
+    </footer>
+
+    <script type="module" src="assets/js/game.js"></script>
+  </body>
+</html>


### PR DESCRIPTION
## Summary
- convert the top navigation links into a single sections dropdown and add a shortcut to the ML mini game
- update shared styles and scripts so the dropdown behaves across desktop and mobile layouts
- add a standalone Model Match mini game page with an interactive machine learning scenario quiz

## Testing
- Not run (not available)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691268bdc91883279de6d9aa4cd127ee)