### PR TITLE
Add transformers dropdown navigation

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -207,74 +207,14 @@ img {
   z-index: 1000;
 }
 
-.nav-dropdown-menu a {
+.nav-dropdown-menu a,
+.nav-dropdown__placeholder {
   display: block;
   padding: 0.35rem 0.25rem;
   border-radius: 0.5rem;
   color: var(--color-muted);
-}
-
-.nav-dropdown-menu a:hover,
-.nav-dropdown-menu a:focus-visible {
-  background: var(--color-accent-muted);
-  color: var(--color-accent);
-  text-decoration: none;
-}
-
-.nav-dropdown-toggle {
-  display: inline-flex;
-  align-items: center;
-  gap: 0.35rem;
   font-size: 0.95rem;
-  font-weight: 500;
-  font-family: inherit;
-  color: var(--color-muted);
-  background: transparent;
-  border: none;
-  cursor: pointer;
-  padding: 0;
-  transition: color 150ms ease;
-}
-
-.nav-dropdown-toggle:hover,
-.nav-dropdown-toggle:focus-visible {
-  color: var(--color-accent);
-}
-
-.nav-dropdown__icon {
-  width: 0.75rem;
-  height: 0.75rem;
-  fill: currentColor;
-  transition: transform 150ms ease;
-}
-
-.nav-item--dropdown[data-open='true'] .nav-dropdown__icon {
-  transform: rotate(180deg);
-}
-
-.nav-dropdown-menu {
-  position: absolute;
-  top: calc(100% + 0.65rem);
-  left: 0;
-  min-width: 200px;
-  display: flex;
-  flex-direction: column;
-  gap: 0.35rem;
-  margin: 0;
-  padding: 0.75rem;
-  list-style: none;
-  background: var(--color-surface);
-  border: 1px solid var(--color-border);
-  border-radius: var(--radius-sm);
-  box-shadow: var(--shadow-lg);
-  z-index: 1000;
-}
-
-.nav-dropdown-menu a {
-  display: block;
-  padding: 0.35rem 0.25rem;
-  border-radius: 0.5rem;
-  color: var(--color-muted);
+  line-height: 1.3;
 }
 
 .nav-dropdown-menu a:hover,
@@ -282,6 +222,14 @@ img {
   background: var(--color-accent-muted);
   color: var(--color-accent);
   text-decoration: none;
+}
+
+.nav-dropdown__placeholder {
+  font-weight: 500;
+  opacity: 0.65;
+  cursor: default;
+  user-select: none;
+  pointer-events: none;
 }
 
 .nav-toggle {

--- a/assets/js/main.js
+++ b/assets/js/main.js
@@ -111,12 +111,20 @@ function formatTitleCase(text) {
 const body = document.body;
 const navToggle = document.querySelector('.nav-toggle');
 const navLinks = document.querySelector('.nav-links');
-const sectionDropdownToggle = document.querySelector('.nav-dropdown-toggle');
-const sectionDropdownMenu = document.getElementById('section-menu');
-const sectionDropdownWrapper =
-  sectionDropdownToggle instanceof HTMLElement
-    ? sectionDropdownToggle.closest('.nav-item--dropdown')
-    : null;
+const navDropdowns = Array.from(document.querySelectorAll('.nav-item--dropdown')).reduce(
+  (accumulator, wrapper) => {
+    if (!(wrapper instanceof HTMLElement)) return accumulator;
+    const toggle = wrapper.querySelector('.nav-dropdown-toggle');
+    const menu = wrapper.querySelector('.nav-dropdown-menu');
+
+    if (toggle instanceof HTMLElement && menu instanceof HTMLElement) {
+      accumulator.push({ wrapper, toggle, menu });
+    }
+
+    return accumulator;
+  },
+  []
+);
 const themeToggle = document.querySelector('.theme-toggle');
 const yearElement = document.querySelector('#year');
 const editToggle = document.querySelector('.edit-toggle');
@@ -649,77 +657,83 @@ function renderAll() {
 }
 
 function setupNav() {
-  const closeDropdown = () => {
-    if (sectionDropdownToggle) {
-      sectionDropdownToggle.setAttribute('aria-expanded', 'false');
-    }
-    if (sectionDropdownMenu) {
-      sectionDropdownMenu.hidden = true;
-    }
-    sectionDropdownWrapper?.setAttribute('data-open', 'false');
+  const focusableSelector = 'a[href], button:not([disabled]), [tabindex]:not([tabindex="-1"])';
+
+  const closeDropdown = (dropdown) => {
+    dropdown.toggle.setAttribute('aria-expanded', 'false');
+    dropdown.menu.hidden = true;
+    dropdown.wrapper.setAttribute('data-open', 'false');
   };
 
-  const openDropdown = () => {
-    if (sectionDropdownToggle) {
-      sectionDropdownToggle.setAttribute('aria-expanded', 'true');
-    }
-    if (sectionDropdownMenu) {
-      sectionDropdownMenu.hidden = false;
-    }
-    sectionDropdownWrapper?.setAttribute('data-open', 'true');
+  const closeAllDropdowns = () => {
+    navDropdowns.forEach((dropdown) => {
+      closeDropdown(dropdown);
+    });
   };
 
-  if (sectionDropdownToggle && sectionDropdownMenu) {
-    closeDropdown();
+  const openDropdown = (dropdown) => {
+    closeAllDropdowns();
+    dropdown.toggle.setAttribute('aria-expanded', 'true');
+    dropdown.menu.hidden = false;
+    dropdown.wrapper.setAttribute('data-open', 'true');
+  };
 
-    sectionDropdownToggle.addEventListener('click', (event) => {
-      event.stopPropagation();
-      const isExpanded = sectionDropdownToggle.getAttribute('aria-expanded') === 'true';
-      if (isExpanded) {
-        closeDropdown();
-      } else {
-        openDropdown();
-      }
-    });
+  if (navDropdowns.length) {
+    navDropdowns.forEach((dropdown) => {
+      closeDropdown(dropdown);
 
-    sectionDropdownToggle.addEventListener('keydown', (event) => {
-      if (event.key === 'ArrowDown') {
-        event.preventDefault();
-        if (sectionDropdownToggle.getAttribute('aria-expanded') !== 'true') {
-          openDropdown();
-        }
-        const firstLink = sectionDropdownMenu.querySelector('a');
-        if (firstLink instanceof HTMLElement) {
-          firstLink.focus();
-        }
-      } else if (event.key === 'Escape') {
-        closeDropdown();
-      }
-    });
-
-    sectionDropdownMenu.addEventListener('click', (event) => {
-      if (event.target instanceof HTMLAnchorElement) {
-        closeDropdown();
-      }
-    });
-
-    sectionDropdownMenu.addEventListener('keydown', (event) => {
-      if (event.key === 'Escape') {
+      dropdown.toggle.addEventListener('click', (event) => {
         event.stopPropagation();
-        closeDropdown();
-        sectionDropdownToggle.focus();
-      }
+        const isExpanded = dropdown.toggle.getAttribute('aria-expanded') === 'true';
+        if (isExpanded) {
+          closeDropdown(dropdown);
+        } else {
+          openDropdown(dropdown);
+        }
+      });
+
+      dropdown.toggle.addEventListener('keydown', (event) => {
+        if (event.key === 'ArrowDown') {
+          event.preventDefault();
+          if (dropdown.toggle.getAttribute('aria-expanded') !== 'true') {
+            openDropdown(dropdown);
+          }
+          const firstItem = dropdown.menu.querySelector(focusableSelector);
+          if (firstItem instanceof HTMLElement) {
+            firstItem.focus();
+          }
+        } else if (event.key === 'Escape') {
+          closeDropdown(dropdown);
+        }
+      });
+
+      dropdown.menu.addEventListener('click', (event) => {
+        if (event.target instanceof HTMLAnchorElement) {
+          closeAllDropdowns();
+        }
+      });
+
+      dropdown.menu.addEventListener('keydown', (event) => {
+        if (event.key === 'Escape') {
+          event.stopPropagation();
+          closeDropdown(dropdown);
+          dropdown.toggle.focus();
+        }
+      });
     });
 
     document.addEventListener('click', (event) => {
-      if (sectionDropdownWrapper && !sectionDropdownWrapper.contains(event.target)) {
-        closeDropdown();
+      const target = event.target;
+      if (!(target instanceof Node)) return;
+      if (navDropdowns.some((dropdown) => dropdown.wrapper.contains(target))) {
+        return;
       }
+      closeAllDropdowns();
     });
 
     document.addEventListener('keydown', (event) => {
       if (event.key === 'Escape') {
-        closeDropdown();
+        closeAllDropdowns();
       }
     });
   }
@@ -727,7 +741,7 @@ function setupNav() {
   if (navToggle) {
     navToggle.addEventListener('click', () => {
       const isExpanded = navToggle.getAttribute('aria-expanded') === 'true';
-      closeDropdown();
+      closeAllDropdowns();
       navToggle.setAttribute('aria-expanded', String(!isExpanded));
       navLinks?.setAttribute('data-visible', String(!isExpanded));
       body.classList.toggle('nav-open', !isExpanded);
@@ -738,7 +752,7 @@ function setupNav() {
         navToggle.setAttribute('aria-expanded', 'false');
         navLinks?.setAttribute('data-visible', 'false');
         body.classList.remove('nav-open');
-        closeDropdown();
+        closeAllDropdowns();
         navToggle.focus();
       }
     });
@@ -748,7 +762,7 @@ function setupNav() {
         navToggle.setAttribute('aria-expanded', 'false');
         navLinks?.setAttribute('data-visible', 'false');
         body.classList.remove('nav-open');
-        closeDropdown();
+        closeAllDropdowns();
       }
     });
   }
@@ -758,7 +772,7 @@ function setupNav() {
       navToggle?.setAttribute('aria-expanded', 'false');
       navLinks.setAttribute('data-visible', 'false');
       body.classList.remove('nav-open');
-      closeDropdown();
+      closeAllDropdowns();
     }
   });
 }

--- a/index.html
+++ b/index.html
@@ -60,7 +60,37 @@
                 <li><a href="#contact">Contact</a></li>
               </ul>
             </li>
-            <li><a href="ml-game.html">Transformer Lab</a></li>
+            <li class="nav-item nav-item--dropdown">
+              <button
+                class="nav-dropdown-toggle"
+                type="button"
+                aria-expanded="false"
+                aria-controls="transformer-menu"
+              >
+                Transformers
+                <svg
+                  class="nav-dropdown__icon"
+                  aria-hidden="true"
+                  focusable="false"
+                  viewBox="0 0 12 12"
+                >
+                  <path d="M2.47 4.47a.75.75 0 0 1 1.06 0L6 6.94l2.47-2.47a.75.75 0 0 1 1.06 1.06l-3 3a.75.75 0 0 1-1.06 0l-3-3a.75.75 0 0 1 0-1.06Z" />
+                </svg>
+              </button>
+              <ul class="nav-dropdown-menu" id="transformer-menu" hidden>
+                <li><a href="ml-game.html">Transformer Lab</a></li>
+                <li>
+                  <span class="nav-dropdown__placeholder" role="text" aria-disabled="true"
+                    >Model cookbook (coming soon)</span
+                  >
+                </li>
+                <li>
+                  <span class="nav-dropdown__placeholder" role="text" aria-disabled="true"
+                    >Prompt gallery (coming soon)</span
+                  >
+                </li>
+              </ul>
+            </li>
           </ul>
           <div class="nav-actions">
             <button class="edit-toggle" type="button" aria-pressed="false" hidden>Edit mode</button>

--- a/ml-game.html
+++ b/ml-game.html
@@ -45,7 +45,32 @@
                 <li><a href="index.html#contact">Contact</a></li>
               </ul>
             </li>
-            <li><a href="ml-game.html" aria-current="page">Transformer Lab</a></li>
+            <li class="nav-item nav-item--dropdown">
+              <button
+                class="nav-dropdown-toggle"
+                type="button"
+                aria-expanded="false"
+                aria-controls="transformer-menu"
+              >
+                Transformers
+                <svg class="nav-dropdown__icon" aria-hidden="true" focusable="false" viewBox="0 0 12 12">
+                  <path d="M2.47 4.47a.75.75 0 0 1 1.06 0L6 6.94l2.47-2.47a.75.75 0 0 1 1.06 1.06l-3 3a.75.75 0 0 1-1.06 0l-3-3a.75.75 0 0 1 0-1.06Z" />
+                </svg>
+              </button>
+              <ul class="nav-dropdown-menu" id="transformer-menu" hidden>
+                <li><a href="ml-game.html" aria-current="page">Transformer Lab</a></li>
+                <li>
+                  <span class="nav-dropdown__placeholder" role="text" aria-disabled="true"
+                    >Model cookbook (coming soon)</span
+                  >
+                </li>
+                <li>
+                  <span class="nav-dropdown__placeholder" role="text" aria-disabled="true"
+                    >Prompt gallery (coming soon)</span
+                  >
+                </li>
+              </ul>
+            </li>
           </ul>
           <div class="nav-actions">
             <button class="theme-toggle" type="button" aria-label="Toggle color theme">


### PR DESCRIPTION
## Summary
- replace the standalone Transformer Lab link with a Transformers dropdown on both pages and stub future resources
- ensure navigation scripts support multiple dropdown menus and collapse them during mobile interactions
- tune dropdown styling so placeholders inherit the same surface treatment and spacing as existing menus

## Testing
- Not run (static site)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691287f1ea3c8327aa1c456b1592110e)