### PR TITLE
Enhance ML lab walkthrough and stage animations

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -1012,17 +1012,42 @@ body.theme-dark .project-card {
 }
 
 .lab-stage__panels {
+  position: relative;
   display: grid;
   gap: 2rem;
+  transition: height 320ms ease;
+}
+
+.lab-stage__panels:not(.is-animating) {
+  transition-duration: 0ms;
 }
 
 .lab-panel {
-  display: none;
+  position: absolute;
+  inset: 0;
+  display: grid;
   gap: 1.75rem;
+  opacity: 0;
+  visibility: hidden;
+  pointer-events: none;
+  transform: translateY(28px);
+  transition: opacity 280ms ease, transform 280ms ease;
 }
 
 .lab-panel.is-active {
-  display: grid;
+  position: relative;
+  visibility: visible;
+}
+
+.lab-panel.is-visible {
+  opacity: 1;
+  pointer-events: auto;
+  transform: translateY(0);
+}
+
+.lab-panel.is-leaving {
+  visibility: visible;
+  transform: translateY(-8px);
 }
 
 .lab-panel__grid {
@@ -1071,6 +1096,133 @@ body.theme-dark .lab-panel__sample code {
   margin: 0;
   color: var(--color-muted);
   font-size: 0.95rem;
+}
+
+.lab-panel__walkthrough {
+  display: grid;
+  gap: 1rem;
+  padding: 1.25rem;
+  border-radius: var(--radius-lg);
+  background: rgba(59, 130, 246, 0.08);
+  border: 1px solid rgba(59, 130, 246, 0.16);
+}
+
+body.theme-dark .lab-panel__walkthrough {
+  background: rgba(96, 165, 250, 0.14);
+  border-color: rgba(96, 165, 250, 0.24);
+}
+
+.lab-panel__walkthrough-title {
+  margin: 0;
+  font-size: 1.05rem;
+  font-weight: 600;
+}
+
+.lab-steps {
+  margin: 0;
+  padding-left: 1.35rem;
+  display: grid;
+  gap: 0.65rem;
+}
+
+.lab-steps li {
+  font-size: 0.95rem;
+  color: var(--color-text);
+}
+
+body.theme-dark .lab-steps li {
+  color: var(--color-muted);
+}
+
+.lab-steps strong {
+  color: var(--color-text);
+}
+
+body.theme-dark .lab-steps strong {
+  color: var(--color-text);
+}
+
+.lab-callout {
+  display: grid;
+  gap: 0.75rem;
+  padding: 1.1rem;
+  border-radius: var(--radius-lg);
+  background: var(--color-surface);
+  box-shadow: var(--shadow-sm);
+}
+
+body.theme-dark .lab-callout {
+  box-shadow: none;
+  background: rgba(15, 23, 42, 0.78);
+}
+
+.lab-callout h5 {
+  margin: 0;
+  font-size: 0.95rem;
+  letter-spacing: 0.01em;
+  text-transform: uppercase;
+  color: var(--color-accent);
+}
+
+.lab-callout p {
+  margin: 0;
+  color: var(--color-muted);
+  font-size: 0.95rem;
+}
+
+.lab-callout__list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: grid;
+  gap: 0.45rem;
+}
+
+.lab-callout__list li {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  font-size: 0.95rem;
+  color: var(--color-muted);
+}
+
+.lab-chip {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 0.2rem 0.6rem;
+  border-radius: 999px;
+  font-size: 0.85rem;
+  font-weight: 600;
+  background: var(--color-accent-muted);
+  color: var(--color-accent);
+  font-family: var(--font-mono);
+  letter-spacing: 0.02em;
+}
+
+.lab-figure {
+  display: grid;
+  gap: 0.75rem;
+  margin: 0;
+  padding: 1rem;
+  border-radius: var(--radius-lg);
+  background: var(--color-surface);
+  box-shadow: var(--shadow-sm);
+}
+
+body.theme-dark .lab-figure {
+  box-shadow: none;
+  background: rgba(15, 23, 42, 0.82);
+}
+
+.lab-figure img {
+  border-radius: var(--radius-sm);
+}
+
+.lab-figure figcaption {
+  margin: 0;
+  color: var(--color-muted);
+  font-size: 0.9rem;
 }
 
 .token-mode-switch {
@@ -1456,6 +1608,34 @@ body.theme-dark .lab-panel__sample code {
   gap: 1.75rem;
   grid-template-columns: minmax(0, 0.9fr) minmax(0, 1.2fr);
   align-items: start;
+}
+
+.pipeline-overview {
+  display: grid;
+  gap: 1rem;
+  margin-bottom: 1.75rem;
+}
+
+.pipeline-overview h3 {
+  margin: 0;
+  font-size: 1.2rem;
+}
+
+.pipeline-overview p {
+  margin: 0;
+  color: var(--color-muted);
+  font-size: 0.95rem;
+}
+
+.pipeline-overview__note {
+  padding: 0.75rem 1rem;
+  border-left: 4px solid var(--color-accent);
+  background: rgba(59, 130, 246, 0.08);
+  border-radius: 0 var(--radius-lg) var(--radius-lg) 0;
+}
+
+body.theme-dark .pipeline-overview__note {
+  background: rgba(96, 165, 250, 0.14);
 }
 
 .pipeline-steps {
@@ -1913,6 +2093,17 @@ body.theme-dark .lab-panel__sample code {
 
   .editor-dialog {
     width: 94vw;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .lab-stage__panels {
+    transition-duration: 0ms !important;
+  }
+
+  .lab-panel {
+    transition: none;
+    transform: none !important;
   }
 }
 

--- a/assets/img/vision-token-grid.svg
+++ b/assets/img/vision-token-grid.svg
@@ -1,0 +1,41 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="480" height="320" viewBox="0 0 480 320" role="img" aria-labelledby="title desc">
+  <title id="title">Six patch grid representing vision transformer tokens</title>
+  <desc id="desc">A two-row grid showing how an image is divided into equal square patches with varied colors.</desc>
+  <defs>
+    <linearGradient id="patchA" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" stop-color="#38bdf8" />
+      <stop offset="100%" stop-color="#0ea5e9" />
+    </linearGradient>
+    <linearGradient id="patchB" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" stop-color="#f97316" />
+      <stop offset="100%" stop-color="#ea580c" />
+    </linearGradient>
+    <linearGradient id="patchC" x1="0%" y1="0%" x2="100%" y2="0%">
+      <stop offset="0%" stop-color="#a855f7" />
+      <stop offset="100%" stop-color="#7c3aed" />
+    </linearGradient>
+    <linearGradient id="patchD" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" stop-color="#22c55e" />
+      <stop offset="100%" stop-color="#16a34a" />
+    </linearGradient>
+    <linearGradient id="patchE" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" stop-color="#facc15" />
+      <stop offset="100%" stop-color="#eab308" />
+    </linearGradient>
+    <linearGradient id="patchF" x1="0%" y1="0%" x2="100%" y2="0%">
+      <stop offset="0%" stop-color="#ef4444" />
+      <stop offset="100%" stop-color="#dc2626" />
+    </linearGradient>
+  </defs>
+  <rect x="0" y="0" width="480" height="320" rx="24" fill="#0f172a" />
+  <g stroke="#1e293b" stroke-width="6" stroke-linejoin="round">
+    <rect x="48" y="48" width="120" height="96" fill="url(#patchA)" />
+    <rect x="180" y="48" width="120" height="96" fill="url(#patchB)" />
+    <rect x="312" y="48" width="120" height="96" fill="url(#patchC)" />
+    <rect x="48" y="176" width="120" height="96" fill="url(#patchD)" />
+    <rect x="180" y="176" width="120" height="96" fill="url(#patchE)" />
+    <rect x="312" y="176" width="120" height="96" fill="url(#patchF)" />
+  </g>
+  <rect x="48" y="48" width="384" height="224" fill="none" stroke="#94a3b8" stroke-width="6" stroke-dasharray="16 16" rx="18" />
+  <text x="240" y="300" fill="#e2e8f0" font-family="'Inter', 'Segoe UI', sans-serif" font-size="22" text-anchor="middle">6 equal patches → 6 image tokens</text>
+</svg>

--- a/assets/js/game.js
+++ b/assets/js/game.js
@@ -188,17 +188,18 @@ function setupBackToTop() {
 
 const TOKEN_MODES = {
   words: {
-    description: 'Word tokens keep whole words intact and make it easy to read the sentence like a human.',
+    description:
+      'Step 1 from the breakdown above keeps whole words intact so you can read the sentence like a human before diving deeper.',
     defaultToken: 'words-transformers'
   },
   subwords: {
     description:
-      'Subword pieces break rarer words into reusable fragments so the model never has to emit an unknown token.',
+      'Step 2 zooms in on reusable pieces—rarer words split into familiar chunks the model can recombine anywhere.',
     defaultToken: 'subwords-trans'
   },
   vision: {
     description:
-      'Vision transformers slice an image into equal patches and treat each patch like a token alongside the class token.',
+      'Step 3 mirrors the image figure below: vision transformers slice an image into equal patches and treat each as a token.',
     defaultToken: 'vision-patch1'
   }
 };
@@ -342,7 +343,7 @@ const TOKEN_DETAILS = {
   },
   'vision-class': {
     title: '[CLS] · vision summary token',
-    summary: 'Aggregates information from all image patches so classifiers have a single vector.',
+    summary: 'Aggregates information from all Step 3 patches in the figure so classifiers have a single vector.',
     facts: [
       { label: 'Role', value: 'Global image descriptor' },
       { label: 'Learns', value: 'To balance texture, color, and layout' }
@@ -350,7 +351,7 @@ const TOKEN_DETAILS = {
   },
   'vision-patch1': {
     title: 'Patch 1 · top-left',
-    summary: 'Represents the first 16×16 region of the image, capturing local edges and colors.',
+    summary: 'Represents the first 16×16 region from the Step 3 grid, capturing local edges and colors.',
     facts: [
       { label: 'Patch size', value: '16 × 16 pixels' },
       { label: 'Focus', value: 'Corner textures and background' }
@@ -358,7 +359,7 @@ const TOKEN_DETAILS = {
   },
   'vision-patch2': {
     title: 'Patch 2 · top-center',
-    summary: 'Next patch across the image, aligned horizontally with Patch 1.',
+    summary: 'Next patch across the Step 3 grid, aligned horizontally with Patch 1.',
     facts: [
       { label: 'Shares', value: 'Overlaps context with neighbors' },
       { label: 'Helps with', value: 'Capturing long horizontal structures' }
@@ -366,7 +367,7 @@ const TOKEN_DETAILS = {
   },
   'vision-patch3': {
     title: 'Patch 3 · top-right',
-    summary: 'Captures the upper-right corner details.',
+    summary: 'Captures the upper-right corner of the Step 3 grid.',
     facts: [
       { label: 'Complement', value: 'Balances the left patches' },
       { label: 'Attention', value: 'Links to distant patches for long-range cues' }
@@ -374,7 +375,7 @@ const TOKEN_DETAILS = {
   },
   'vision-patch4': {
     title: 'Patch 4 · bottom-left',
-    summary: 'Begins the second row of patches with new texture information.',
+    summary: 'Begins the second row of the Step 3 grid with new texture information.',
     facts: [
       { label: 'Spatial role', value: 'Connects top and bottom halves' },
       { label: 'Combines', value: 'Local features with global context' }
@@ -382,7 +383,7 @@ const TOKEN_DETAILS = {
   },
   'vision-patch5': {
     title: 'Patch 5 · bottom-center',
-    summary: 'Middle patch in the second row, bridging surrounding regions.',
+    summary: 'Middle patch in the second row of the Step 3 grid, bridging surrounding regions.',
     facts: [
       { label: 'Attention', value: 'Shares information with all neighbors' },
       { label: 'Helps with', value: 'Capturing shapes across rows' }
@@ -390,7 +391,7 @@ const TOKEN_DETAILS = {
   },
   'vision-patch6': {
     title: 'Patch 6 · bottom-right',
-    summary: 'Completes the grid and preserves boundary information.',
+    summary: 'Completes the Step 3 grid and preserves boundary information.',
     facts: [
       { label: 'Role', value: 'Edges and corners' },
       { label: 'Learns', value: 'How borders differ from the center' }
@@ -614,9 +615,9 @@ const ATTENTION_HEADS = {
 const PIPELINE_STEPS = [
   {
     id: 'mix',
-    title: 'Self-attention mixes contextual clues',
+    title: 'Step 1 · Mix context with self-attention',
     description:
-      'Each query weights the value vectors from every token and sums them into a context-rich representation.',
+      'Match the overview above: each query weights value vectors from every token and sums them into a context-rich representation.',
     highlights: [
       {
         title: 'Weighted values',
@@ -631,9 +632,9 @@ const PIPELINE_STEPS = [
   },
   {
     id: 'ffn',
-    title: 'Feed-forward layers reshape meaning',
+    title: 'Step 2 · Feed-forward layers reshape meaning',
     description:
-      'A tiny shared MLP refines every token independently, adding non-linear features after attention.',
+      'The shared MLP sharpens each token individually—exactly what Step 2 in the checklist promises.',
     highlights: [
       {
         title: 'Non-linearity',
@@ -648,9 +649,9 @@ const PIPELINE_STEPS = [
   },
   {
     id: 'residual',
-    title: 'Residual connections keep information flowing',
+    title: 'Step 3 · Residual connections keep information flowing',
     description:
-      'Skip connections and layer normalisation stabilise training and preserve the original signal.',
+      'Skip connections and layer normalisation deliver the stability called out in Step 3 of the overview.',
     highlights: [
       {
         title: 'Skip paths',
@@ -665,9 +666,9 @@ const PIPELINE_STEPS = [
   },
   {
     id: 'prediction',
-    title: 'Output heads turn features into predictions',
+    title: 'Step 4 · Output heads turn features into predictions',
     description:
-      'Depending on the task, the model reads the [CLS] token, the final token, or all tokens to produce answers.',
+      'Finish the loop from Step 4: the task head reads the refined tokens and turns them into answers.',
     highlights: [
       {
         title: 'CLS classifier',
@@ -684,41 +685,131 @@ const PIPELINE_STEPS = [
 
 function setupStageNavigation() {
   const nav = document.querySelector('[data-stage-nav]');
+  const panelsWrapper = document.querySelector('.lab-stage__panels');
   const panels = new Map();
   document.querySelectorAll('[data-stage-panel]').forEach((panel) => {
+    if (!panel.dataset.stagePanel) return;
     panels.set(panel.dataset.stagePanel, panel);
+    panel.classList.remove('is-active', 'is-visible', 'is-leaving');
+    panel.setAttribute('aria-hidden', 'true');
   });
   if (!nav || panels.size === 0) return;
 
   const buttons = Array.from(nav.querySelectorAll('[data-stage]'));
   if (buttons.length === 0) return;
 
-  const activateStage = (stageId) => {
+  let activeStageId = null;
+
+  const setButtonState = (stageId) => {
     buttons.forEach((button) => {
       const isActive = button.dataset.stage === stageId;
       button.classList.toggle('is-active', isActive);
-      const panel = panels.get(button.dataset.stage);
-      if (panel) {
-        panel.classList.toggle('is-active', isActive);
+    });
+  };
+
+  const finalizePanel = (panel) => {
+    if (!panel) return;
+    panel.classList.remove('is-active', 'is-leaving');
+    panel.setAttribute('aria-hidden', 'true');
+  };
+
+  const showPanel = (stageId, { immediate = false } = {}) => {
+    const nextPanel = panels.get(stageId);
+    if (!nextPanel) return;
+
+    const currentPanel = activeStageId ? panels.get(activeStageId) : null;
+    if (nextPanel === currentPanel && nextPanel.classList.contains('is-visible')) {
+      setButtonState(stageId);
+      return;
+    }
+
+    setButtonState(stageId);
+
+    const reduceMotion = immediate || prefersReducedMotion?.matches;
+
+    if (currentPanel && currentPanel !== nextPanel) {
+      currentPanel.classList.remove('is-visible');
+      currentPanel.classList.add('is-leaving');
+      currentPanel.setAttribute('aria-hidden', 'true');
+    }
+
+    nextPanel.classList.add('is-active');
+    nextPanel.classList.remove('is-leaving');
+    nextPanel.setAttribute('aria-hidden', 'false');
+
+    if (panelsWrapper) {
+      if (reduceMotion) {
+        panelsWrapper.classList.remove('is-animating');
+        panelsWrapper.style.height = '';
+      } else {
+        const fromHeight = currentPanel ? currentPanel.offsetHeight : nextPanel.offsetHeight;
+        const toHeight = nextPanel.offsetHeight;
+        panelsWrapper.style.height = `${fromHeight}px`;
+        panelsWrapper.classList.add('is-animating');
+
+        requestAnimationFrame(() => {
+          panelsWrapper.style.height = `${toHeight}px`;
+        });
+
+        if (Math.abs(fromHeight - toHeight) < 1) {
+          panelsWrapper.classList.remove('is-animating');
+          panelsWrapper.style.height = '';
+        } else {
+          const handleHeightTransitionEnd = (event) => {
+            if (event.target !== panelsWrapper || event.propertyName !== 'height') return;
+            panelsWrapper.removeEventListener('transitionend', handleHeightTransitionEnd);
+            panelsWrapper.classList.remove('is-animating');
+            panelsWrapper.style.height = '';
+          };
+          panelsWrapper.addEventListener('transitionend', handleHeightTransitionEnd);
+        }
       }
+    }
+
+    const enterPanel = () => {
+      nextPanel.classList.add('is-visible');
+    };
+
+    if (reduceMotion) {
+      enterPanel();
+      if (currentPanel && currentPanel !== nextPanel) {
+        finalizePanel(currentPanel);
+      }
+      activeStageId = stageId;
+      return;
+    }
+
+    requestAnimationFrame(() => {
+      requestAnimationFrame(enterPanel);
     });
 
-    if (!panels.has(stageId)) {
-      panels.forEach((panel, id) => {
-        panel.classList.toggle('is-active', id === stageId);
-      });
+    if (currentPanel && currentPanel !== nextPanel) {
+      const handleLeave = (event) => {
+        if (event.target !== currentPanel || event.propertyName !== 'opacity') return;
+        currentPanel.removeEventListener('transitionend', handleLeave);
+        finalizePanel(currentPanel);
+      };
+      currentPanel.addEventListener('transitionend', handleLeave);
     }
+
+    const handleEnter = (event) => {
+      if (event.target !== nextPanel || event.propertyName !== 'opacity') return;
+      nextPanel.removeEventListener('transitionend', handleEnter);
+    };
+    nextPanel.addEventListener('transitionend', handleEnter);
+
+    activeStageId = stageId;
   };
 
   buttons.forEach((button) => {
     button.addEventListener('click', () => {
-      activateStage(button.dataset.stage);
+      showPanel(button.dataset.stage);
     });
   });
 
   const initialStage =
     buttons.find((button) => button.classList.contains('is-active'))?.dataset.stage || buttons[0].dataset.stage;
-  activateStage(initialStage);
+  showPanel(initialStage, { immediate: true });
 }
 
 function setupTokenExplorer() {
@@ -742,7 +833,8 @@ function setupTokenExplorer() {
   const defaultInspector = {
     title: titleEl?.textContent || 'Choose a token to inspect',
     summary:
-      summaryEl?.textContent || 'Toggle between token views and tap a token to see how transformers break down the input.'
+      summaryEl?.textContent ||
+      'Toggle between the three steps above and tap a token to see how transformers break down the input.'
   };
 
   const renderFacts = (facts) => {

--- a/ml-game.html
+++ b/ml-game.html
@@ -110,6 +110,34 @@
                       <p class="lab-panel__note" data-token-mode-description>
                         Word tokens keep whole words intact and map closely to how humans read the sentence.
                       </p>
+                      <div class="lab-panel__walkthrough">
+                        <h4 class="lab-panel__walkthrough-title">Step-by-step breakdown</h4>
+                        <ol class="lab-steps">
+                          <li>
+                            <strong>Step 1 · Read the sentence</strong>
+                            — follow the intact words to see the story the model receives.
+                          </li>
+                          <li>
+                            <strong>Step 2 · Spot reusable pieces</strong>
+                            — switch to subwords to watch rarer terms split into familiar chunks.
+                          </li>
+                          <li>
+                            <strong>Step 3 · Map pixels to tokens</strong>
+                            — the vision view shows the same idea applied to an image grid.
+                          </li>
+                        </ol>
+                        <div class="lab-callout" role="note">
+                          <h5>Dissecting the sample sentence</h5>
+                          <ul class="lab-callout__list">
+                            <li><span class="lab-chip">Transformers</span> introduce the topic.</li>
+                            <li><span class="lab-chip">help models</span> tells us the action.</li>
+                            <li><span class="lab-chip">connect ideas</span> reveals the outcome.</li>
+                          </ul>
+                          <p>
+                            Tap any token to see how the inspector elaborates on these roles in plain language.
+                          </p>
+                        </div>
+                      </div>
                       <div class="token-mode-switch" data-token-mode-switch>
                         <button class="is-active" type="button" data-token-mode="words">Word tokens</button>
                         <button type="button" data-token-mode="subwords">Subword pieces</button>
@@ -155,6 +183,15 @@
                         </p>
                         <dl class="token-inspector__facts" data-token-facts></dl>
                       </aside>
+                      <figure class="lab-figure">
+                        <img
+                          src="assets/img/vision-token-grid.svg"
+                          width="480"
+                          height="320"
+                          alt="Diagram showing a six-patch grid that becomes six image tokens"
+                        />
+                        <figcaption>Image patches become tokens just like the words above—Step 3 brings text and vision together.</figcaption>
+                      </figure>
                     </div>
                   </div>
                 </section>
@@ -219,6 +256,20 @@
 
                 <section class="lab-panel" data-stage-panel="outputs">
                   <div class="pipeline-layout">
+                    <div class="pipeline-overview">
+                      <h3>How the model finishes the thought</h3>
+                      <p>
+                        The sentence above threads through four repeatable moves. Follow the numbered list, then use the
+                        inspector to dive deeper into each stage.
+                      </p>
+                      <ol class="lab-steps">
+                        <li><strong>Step 1 · Mix context</strong> — attention blends clues from every token.</li>
+                        <li><strong>Step 2 · Feed-forward</strong> — an MLP sharpens each token individually.</li>
+                        <li><strong>Step 3 · Residual &amp; norm</strong> — skip paths keep the story stable.</li>
+                        <li><strong>Step 4 · Output head</strong> — the task head turns features into predictions.</li>
+                      </ol>
+                      <p class="pipeline-overview__note">The active step below mirrors these headings for quick cross-reference.</p>
+                    </div>
                     <div class="pipeline-steps" data-pipeline-steps>
                       <button class="pipeline-step is-active" type="button" data-step="mix">1 · Mix context</button>
                       <button class="pipeline-step" type="button" data-step="ffn">2 · Feed-forward</button>


### PR DESCRIPTION
## Summary
- add step-by-step explanations and callouts to the tokens and outputs panels, including a supporting vision patch figure
- synchronize inspector and pipeline copy with the new walkthrough content and add the illustrative SVG asset
- animate stage transitions with CSS class-driven opacity/transform changes and updated JS navigation logic, including a reduced-motion fallback

## Testing
- Manual verification in browser

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691287f47a608327acad95f425afce80)