### PR TITLE
Add dynamic stage explanations to transformer lab

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,3 +73,4 @@ These commands are quick syntax validations and do not execute the scripts.
 - Component tokens, layout spacing, and editor styles all live in `assets/css/style.css`.
 - `assets/js/content.js` holds the default data structure for all editable sections. Update the defaults there if you want different starter content shipped with the site.
 - `assets/js/main.js` wires together navigation, theming, edit-mode dialogs, LinkedIn synchronization, and persistence.
+- `assets/js/game.js` drives the interactive transformer lab—add or tweak a stage by editing the `STAGE_EXPLANATIONS` object so the shared placeholders in `ml-game.html` pick up the new copy automatically.

--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -1100,6 +1100,11 @@ body.theme-dark .project-card {
   color: var(--color-muted);
 }
 
+.lab-panel__summary {
+  margin: 0;
+  color: var(--color-muted);
+}
+
 .lab-panel__sample code {
   display: inline-block;
   padding: 0.35rem 0.55rem;
@@ -1130,6 +1135,10 @@ body.theme-dark .lab-panel__sample code {
   border: 1px solid rgba(59, 130, 246, 0.16);
 }
 
+.lab-panel__walkthrough[hidden] {
+  display: none;
+}
+
 body.theme-dark .lab-panel__walkthrough {
   background: rgba(96, 165, 250, 0.14);
   border-color: rgba(96, 165, 250, 0.24);
@@ -1139,6 +1148,23 @@ body.theme-dark .lab-panel__walkthrough {
   margin: 0;
   font-size: 1.05rem;
   font-weight: 600;
+}
+
+.lab-panel__bullet-list {
+  margin: 0;
+  padding-left: 1.2rem;
+  display: grid;
+  gap: 0.4rem;
+  color: var(--color-muted);
+  font-size: 0.95rem;
+}
+
+.lab-panel__bullet-list li {
+  margin: 0;
+}
+
+.lab-panel__bullet-list[hidden] {
+  display: none;
 }
 
 .lab-steps {

--- a/ml-game.html
+++ b/ml-game.html
@@ -104,39 +104,19 @@
                 <section class="lab-panel is-active" data-stage-panel="tokens">
                   <div class="lab-panel__grid">
                     <div class="lab-panel__intro">
-                      <h3>Tokens are the transformer's vocabulary</h3>
-                      <p>We reuse the prompt below across every stage.</p>
+                      <h3 data-stage-heading>Choose a stage to explore</h3>
+                      <p class="lab-panel__summary" data-stage-summary>
+                        The copy below updates when you switch stages so every panel shares the same plain-language context.
+                      </p>
+                      <div class="sr-only" role="status" aria-live="polite" data-stage-announcer></div>
                       <p class="lab-panel__sample"><code>Transformers help models connect ideas.</code></p>
                       <p class="lab-panel__note" data-token-mode-description>
                         Word tokens keep whole words intact and map closely to how humans read the sentence.
                       </p>
-                      <div class="lab-panel__walkthrough">
-                        <h4 class="lab-panel__walkthrough-title">Step-by-step breakdown</h4>
-                        <ol class="lab-steps">
-                          <li>
-                            <strong>Step 1 · Read the sentence</strong>
-                            — follow the intact words to see the story the model receives.
-                          </li>
-                          <li>
-                            <strong>Step 2 · Spot reusable pieces</strong>
-                            — switch to subwords to watch rarer terms split into familiar chunks.
-                          </li>
-                          <li>
-                            <strong>Step 3 · Map pixels to tokens</strong>
-                            — the vision view shows the same idea applied to an image grid.
-                          </li>
-                        </ol>
-                        <div class="lab-callout" role="note">
-                          <h5>Dissecting the sample sentence</h5>
-                          <ul class="lab-callout__list">
-                            <li><span class="lab-chip">Transformers</span> introduce the topic.</li>
-                            <li><span class="lab-chip">help models</span> tells us the action.</li>
-                            <li><span class="lab-chip">connect ideas</span> reveals the outcome.</li>
-                          </ul>
-                          <p>
-                            Tap any token to see how the inspector elaborates on these roles in plain language.
-                          </p>
-                        </div>
+                      <div class="lab-panel__walkthrough" data-stage-walkthrough hidden>
+                        <h4 class="lab-panel__walkthrough-title" data-stage-example-title>Stage example</h4>
+                        <p data-stage-example-text></p>
+                        <ul class="lab-panel__bullet-list" data-stage-bullets></ul>
                       </div>
                       <div class="token-mode-switch" data-token-mode-switch>
                         <button class="is-active" type="button" data-token-mode="words">Word tokens</button>


### PR DESCRIPTION
## Summary
- replace the static copy in the tokens panel with data-driven placeholders and hide the walkthrough container when a stage has no notes
- add stage explanations plus navigation logic that injects plain-language text with aria-live announcements for each stage
- document how to add or adjust stages via `STAGE_EXPLANATIONS` in the README

## Testing
- node --check assets/js/game.js


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691ab2b1254c8327bc483f40662917e1)