### PR TITLE
Add wide layout toggle for Endless Depths layout

### DIFF
--- a/assets/css/endless-depths.css
+++ b/assets/css/endless-depths.css
@@ -32,6 +32,11 @@
   gap: 0.75rem;
 }
 
+#layout-toggle.is-active {
+  color: var(--color-accent);
+  border-color: var(--color-accent);
+}
+
 .depths-layout {
   display: grid;
   grid-template-columns: 280px 1fr 320px;
@@ -41,13 +46,23 @@
   border-top: 1px solid var(--color-border);
 }
 
+.depths-layout--wide {
+  grid-template-columns: 1fr;
+  grid-template-areas:
+    'playfield'
+    'sidebar-left'
+    'sidebar-right';
+  align-items: start;
+}
+
 @media (max-width: 1100px) {
   .depths-layout {
     grid-template-columns: 1fr;
   }
 
   #canvas-container {
-    height: 520px;
+    min-height: clamp(480px, 65vh, 80vh);
+    height: clamp(480px, 65vh, 80vh);
   }
 }
 
@@ -56,10 +71,18 @@
   gap: 1rem;
 }
 
+.depths-layout--wide .panel-column {
+  grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+}
+
 .playfield {
   display: grid;
   gap: 0.75rem;
   min-width: 0;
+}
+
+.depths-layout--wide .playfield {
+  grid-area: playfield;
 }
 
 #game-wrapper {
@@ -68,13 +91,23 @@
   max-width: none;
 }
 
+.depths-layout--wide #sidebar-left {
+  grid-area: sidebar-left;
+}
+
+.depths-layout--wide #sidebar-right {
+  grid-area: sidebar-right;
+}
+
 #canvas-container {
   position: relative;
   background: #0b0b11;
   border: 1px solid var(--color-border);
   border-radius: var(--radius-lg);
   box-shadow: var(--shadow-sm);
-  min-height: 580px;
+  min-height: clamp(560px, 72vh, 80vh);
+  height: clamp(560px, 72vh, 80vh);
+  max-height: 80vh;
   overflow: hidden;
 }
 

--- a/assets/js/endless-depths.js
+++ b/assets/js/endless-depths.js
@@ -4,6 +4,7 @@ const VIEW_H = 12;
 const MAP_W = 60;
 const MAP_H = 45;
 const STATE_KEY = 'endless-depths-state-v1';
+const LAYOUT_PREF_KEY = 'endless-depths-layout';
 
 const COLORS = {
   floor: '#151515',
@@ -363,6 +364,32 @@ class LootItem extends Entity {
   }
 }
 
+function setLayoutMode(isWide) {
+  const wrapper = document.getElementById('game-wrapper');
+  const toggle = document.getElementById('layout-toggle');
+  if (wrapper) wrapper.classList.toggle('depths-layout--wide', isWide);
+  if (toggle) {
+    toggle.setAttribute('aria-pressed', String(isWide));
+    toggle.classList.toggle('is-active', isWide);
+    toggle.innerText = isWide ? 'Wide view: On' : 'Wide view';
+  }
+
+  try {
+    localStorage.setItem(LAYOUT_PREF_KEY, isWide ? 'wide' : 'default');
+  } catch (error) {
+    console.warn('Unable to save layout preference', error);
+  }
+}
+
+function loadLayoutPreference() {
+  try {
+    return localStorage.getItem(LAYOUT_PREF_KEY);
+  } catch (error) {
+    console.warn('Unable to read layout preference', error);
+    return null;
+  }
+}
+
 function init() {
   canvas = document.getElementById('gameCanvas');
   ctx = canvas.getContext('2d');
@@ -375,6 +402,15 @@ function init() {
     document.getElementById('overlay-msg').innerText = 'Cache cleared. Start a fresh run when ready!';
     document.getElementById('new-run-btn').classList.add('hidden');
     document.getElementById('start-btn').innerText = 'Enter Dungeon';
+  });
+
+  const layoutToggle = document.getElementById('layout-toggle');
+  const pref = loadLayoutPreference();
+  setLayoutMode(pref === 'wide');
+  layoutToggle?.addEventListener('click', () => {
+    const wrapper = document.getElementById('game-wrapper');
+    const nextWide = !wrapper?.classList.contains('depths-layout--wide');
+    setLayoutMode(nextWide);
   });
 
   document.getElementById('start-btn').onclick = () => startGame(!!loadSavedState());

--- a/endless-depths.html
+++ b/endless-depths.html
@@ -85,6 +85,7 @@
                 </p>
               </div>
               <div class="depths-actions">
+                <button class="button button--ghost" type="button" id="layout-toggle" aria-pressed="false">Wide view</button>
                 <button class="button button--ghost" type="button" id="clear-cache-btn">Reset saved run</button>
               </div>
             </header>


### PR DESCRIPTION
## Summary
- add a Wide view toggle that persists and activates a playfield-focused layout for Endless Depths
- update grid and panel stacking styles to support the wide layout while keeping responsive fallbacks
- let the canvas container grow with viewport height up to 80vh for more screen space

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6921371314b48327a642fdf53ac9cd11)