### PR TITLE
Fix durability persistence during item deserialization

### DIFF
--- a/assets/js/endless-depths.js
+++ b/assets/js/endless-depths.js
@@ -1493,8 +1493,12 @@ function serializeItem(item) {
 function deserializeItem(raw) {
   if (!raw) return null;
   const item = new Item(raw.name, raw.type, raw.rarity, raw.stats, raw.weight, raw.stack, raw.spriteName);
-  if (raw.maxDurability) item.maxDurability = raw.maxDurability;
-  if (raw.durability) item.durability = raw.durability;
+  if (raw.maxDurability !== undefined && raw.maxDurability !== null) item.maxDurability = raw.maxDurability;
+  if (raw.durability !== undefined && raw.durability !== null) {
+    item.durability = raw.durability;
+  } else {
+    console.warn('deserializeItem: missing durability for item', raw.name);
+  }
   return item;
 }
 


### PR DESCRIPTION
## Summary
- ensure `deserializeItem` assigns durability and maxDurability even when zero values are saved
- add a warning when durability data is missing to avoid silent resets

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6923b080120c8327b7fde9b58a10b7b5)