### PR TITLE
Fix stair spawning coordinates

### DIFF
--- a/assets/js/endless-depths.js
+++ b/assets/js/endless-depths.js
@@ -1354,7 +1354,7 @@ function createProjectile(x1, y1, x2, y2, type) {
 }
 
 function spawnStairs(x, y) {
-  entities.push(new Entity(x + 0.5, y + 0.5, 'stairs', '#fff', 'Stairs', false));
+  entities.push(new Entity(x, y, 'stairs', '#fff', 'Stairs', false));
   log('Way open!', 'log-loot');
 }
 


### PR DESCRIPTION
## Summary
- update stair spawning to use integer tile coordinates for consistent interactions

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6923b0814cd48327a7012ed172a48c82)