### PR TITLE
Add K-means playground and navigation link

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -681,6 +681,173 @@ body.theme-dark .project-card {
   border: 0;
 }
 
+
+.ml-playground-page {
+  padding: 2.5rem 0 3.5rem;
+  display: grid;
+  gap: 2rem;
+}
+
+.ml-playground__header h1 {
+  margin-bottom: 0.5rem;
+}
+
+.ml-playground__lead {
+  max-width: 70ch;
+  color: var(--color-muted);
+}
+
+.ml-toolbar {
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-lg);
+  padding: 1rem 1.25rem;
+  background: var(--color-surface);
+  box-shadow: var(--shadow-sm);
+  display: flex;
+  gap: 1rem;
+  align-items: center;
+}
+
+.ml-toolbar label {
+  font-weight: 600;
+  display: block;
+  margin-bottom: 0.35rem;
+}
+
+.ml-toolbar select {
+  min-height: 44px;
+  padding: 0.5rem 0.75rem;
+  border-radius: var(--radius-sm);
+  border: 1px solid var(--color-border);
+  background: var(--color-bg);
+}
+
+.ml-playground {
+  display: flex;
+  gap: 1.5rem;
+  align-items: flex-start;
+  flex-wrap: wrap;
+}
+
+.ml-playground-main {
+  flex: 2;
+  min-width: min(680px, 100%);
+  display: grid;
+  gap: 1rem;
+}
+
+#kmeans-canvas {
+  width: 100%;
+  height: auto;
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-lg);
+  background: radial-gradient(circle at 20% 20%, rgba(59, 130, 246, 0.04), transparent),
+    radial-gradient(circle at 80% 40%, rgba(22, 163, 74, 0.04), transparent),
+    var(--color-surface);
+  box-shadow: var(--shadow-sm);
+}
+
+.ml-controls {
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-lg);
+  padding: 1rem 1.25rem;
+  background: var(--color-surface);
+  box-shadow: var(--shadow-sm);
+  display: grid;
+  gap: 0.75rem;
+}
+
+.ml-controls label {
+  font-weight: 600;
+}
+
+.ml-controls input[type='number'] {
+  max-width: 160px;
+  padding: 0.5rem 0.75rem;
+  border-radius: var(--radius-sm);
+  border: 1px solid var(--color-border);
+  background: var(--color-bg);
+}
+
+.ml-controls button {
+  padding: 0.7rem 0.85rem;
+  border-radius: var(--radius-sm);
+  border: 1px solid var(--color-border);
+  background: linear-gradient(135deg, rgba(59, 130, 246, 0.1), rgba(59, 130, 246, 0.08));
+  cursor: pointer;
+  font-weight: 600;
+  transition: border-color 150ms ease, transform 150ms ease;
+}
+
+.ml-controls button:hover,
+.ml-controls button:focus-visible {
+  border-color: var(--color-accent);
+  transform: translateY(-1px);
+}
+
+.ml-controls button:disabled {
+  opacity: 0.6;
+  cursor: not-allowed;
+  transform: none;
+}
+
+.ml-hint {
+  color: var(--color-muted);
+  margin: 0;
+}
+
+.ml-sidebar {
+  flex: 1;
+  min-width: min(320px, 100%);
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-lg);
+  padding: 1rem 1.25rem;
+  background: var(--color-surface);
+  box-shadow: var(--shadow-sm);
+  display: grid;
+  gap: 0.85rem;
+}
+
+.ml-sidebar button {
+  padding: 0.65rem 0.85rem;
+  border-radius: var(--radius-sm);
+  border: 1px solid var(--color-border);
+  background: var(--color-bg);
+  cursor: pointer;
+  font-weight: 600;
+}
+
+.ml-sidebar table {
+  width: 100%;
+  border-collapse: collapse;
+  font-size: 0.95rem;
+}
+
+.ml-sidebar th,
+.ml-sidebar td {
+  border: 1px solid var(--color-border);
+  padding: 0.4rem 0.5rem;
+  text-align: left;
+}
+
+.ml-sidebar thead {
+  background: var(--color-bg);
+}
+
+.ml-table--nearest {
+  color: var(--color-success);
+  font-weight: 700;
+}
+
+.ml-sidebar p {
+  margin: 0;
+}
+
+.ml-playground .card__eyebrow {
+  margin: 0;
+}
+
+
 @media (max-width: 960px) {
   .hero__layout {
     grid-template-columns: 1fr;
@@ -696,6 +863,14 @@ body.theme-dark .project-card {
 
   .sidebar {
     grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  }
+
+  .ml-playground {
+    flex-direction: column;
+  }
+
+  .ml-playground-main {
+    min-width: 100%;
   }
 
   .lab-panel__grid,

--- a/assets/js/main.js
+++ b/assets/js/main.js
@@ -1526,15 +1526,46 @@ function getFieldValue(form, name) {
   return '';
 }
 
+const hasContentScaffold = Boolean(
+  heroElements.eyebrow &&
+  heroElements.title &&
+  heroElements.lead &&
+  heroElements.primary &&
+  heroElements.secondary &&
+  heroElements.current &&
+  heroElements.focus &&
+  aboutElements.title &&
+  aboutElements.body &&
+  learningElements.title &&
+  learningElements.list &&
+  learningElements.empty &&
+  postElements.title &&
+  postElements.cta &&
+  postElements.list &&
+  postElements.empty &&
+  projectElements.title &&
+  projectElements.list &&
+  projectElements.empty &&
+  sidebarElements.container &&
+  sidebarElements.empty &&
+  contactElements.title &&
+  contactElements.body &&
+  contactElements.actions &&
+  contactElements.meta
+);
+
 if (yearElement) {
   yearElement.textContent = String(new Date().getFullYear());
 }
 
-renderAll();
 setupNav();
 setupTheme();
 setupBackToTop();
-setupManagementDialog();
-setupEditors();
-populateExperienceFromLinkedIn();
+
+if (hasContentScaffold) {
+  renderAll();
+  setupManagementDialog();
+  setupEditors();
+  populateExperienceFromLinkedIn();
+}
 

--- a/assets/js/ml-playground.js
+++ b/assets/js/ml-playground.js
@@ -1,0 +1,498 @@
+const MLPlayground = (() => {
+  const POINT_RADIUS = 7;
+  const CENTROID_RADIUS = 10;
+  const CLUSTER_COLORS = [
+    '#3b82f6',
+    '#f97316',
+    '#22c55e',
+    '#a855f7',
+    '#ec4899',
+    '#06b6d4',
+    '#eab308',
+    '#ef4444'
+  ];
+
+  let canvas;
+  let ctx;
+  let kInput;
+  let btnInit;
+  let btnStep;
+  let btnRun;
+  let btnReset;
+  let btnClear;
+  let btnTogglePanel;
+  let statusK;
+  let statusIter;
+  let statusSSE;
+  let calculationPanel;
+  let calculationSSE;
+  let distanceTable;
+  let selectedPointLabel;
+
+  const state = {
+    points: [],
+    centroids: [],
+    currentK: 3,
+    iteration: 0,
+    selectedPointId: null,
+    dragPointId: null,
+    isRunning: false,
+    sse: null
+  };
+
+  const createId = () =>
+    typeof crypto !== 'undefined' && typeof crypto.randomUUID === 'function'
+      ? crypto.randomUUID()
+      : `id-${Math.random().toString(36).slice(2, 10)}`;
+
+  function init() {
+    canvas = document.getElementById('kmeans-canvas');
+    ctx = canvas?.getContext('2d') ?? null;
+    kInput = document.getElementById('k-input');
+    btnInit = document.getElementById('btn-init-centroids');
+    btnStep = document.getElementById('btn-step');
+    btnRun = document.getElementById('btn-run');
+    btnReset = document.getElementById('btn-reset-clustering');
+    btnClear = document.getElementById('btn-clear-points');
+    btnTogglePanel = document.getElementById('btn-toggle-calculations');
+    statusK = document.getElementById('status-k');
+    statusIter = document.getElementById('status-iter');
+    statusSSE = document.getElementById('status-sse');
+    calculationPanel = document.getElementById('calculation-panel');
+    calculationSSE = document.getElementById('calculation-sse');
+    distanceTable = document.querySelector('#distance-table tbody');
+    selectedPointLabel = document.getElementById('selected-point-label');
+
+    if (!canvas || !ctx) return;
+
+    state.currentK = clampK(Number(kInput?.value) || 3);
+    updateStatus();
+    attachEvents();
+    draw();
+  }
+
+  function clampK(value) {
+    return Math.min(8, Math.max(1, Math.round(value)));
+  }
+
+  function attachEvents() {
+    canvas.addEventListener('mousedown', handleCanvasMouseDown);
+    canvas.addEventListener('mousemove', handleCanvasMouseMove);
+    canvas.addEventListener('mouseup', handleCanvasMouseUp);
+    canvas.addEventListener('mouseleave', handleCanvasMouseUp);
+
+    kInput?.addEventListener('change', () => {
+      const newK = clampK(Number(kInput.value));
+      kInput.value = String(newK);
+      state.currentK = newK;
+      state.iteration = 0;
+      statusIter.textContent = '0';
+      statusK.textContent = String(newK);
+      resetAssignments();
+      if (state.points.length >= state.currentK) {
+        initializeCentroids(state.currentK);
+        assignPointsToNearestCentroid();
+        recomputeCentroids();
+        updateAfterStateChange();
+      } else {
+        updateSSE(null);
+        draw();
+      }
+    });
+
+    btnInit?.addEventListener('click', () => {
+      state.iteration = 0;
+      const initialized = initializeCentroids(state.currentK);
+      if (initialized) {
+        assignPointsToNearestCentroid();
+        recomputeCentroids();
+      }
+      updateAfterStateChange();
+    });
+
+    btnStep?.addEventListener('click', () => {
+      if (!ensureCentroids()) return;
+      stepKMeans();
+      draw();
+    });
+
+    btnRun?.addEventListener('click', () => {
+      runToConvergence();
+    });
+
+    btnReset?.addEventListener('click', () => {
+      resetAssignments();
+      draw();
+    });
+
+    btnClear?.addEventListener('click', () => {
+      clearAll();
+    });
+
+    btnTogglePanel?.addEventListener('click', () => {
+      const isExpanded = btnTogglePanel.getAttribute('aria-expanded') === 'true';
+      btnTogglePanel.setAttribute('aria-expanded', String(!isExpanded));
+      btnTogglePanel.textContent = isExpanded ? 'Show calculation process' : 'Hide calculation process';
+      if (calculationPanel) {
+        calculationPanel.hidden = isExpanded;
+      }
+      updateCalculationPanel();
+    });
+  }
+
+  function handleCanvasMouseDown(event) {
+    const position = getCanvasPosition(event);
+    const existingPoint = findPointAt(position.x, position.y);
+
+    if (event.shiftKey && existingPoint) {
+      removePoint(existingPoint.id);
+      return;
+    }
+
+    if (existingPoint) {
+      state.selectedPointId = existingPoint.id;
+      state.dragPointId = existingPoint.id;
+      draw();
+      updateCalculationPanel();
+      return;
+    }
+
+    if (!event.shiftKey) {
+      addPoint(position.x, position.y);
+      if (state.centroids.length) {
+        assignPointsToNearestCentroid();
+        recomputeCentroids();
+        updateAfterStateChange();
+      } else {
+        draw();
+      }
+    }
+  }
+
+  function handleCanvasMouseMove(event) {
+    if (!state.dragPointId) return;
+    const position = getCanvasPosition(event);
+    const point = state.points.find((p) => p.id === state.dragPointId);
+    if (point) {
+      point.x = position.x;
+      point.y = position.y;
+      draw();
+    }
+  }
+
+  function handleCanvasMouseUp() {
+    if (!state.dragPointId) return;
+    state.dragPointId = null;
+    if (state.centroids.length) {
+      assignPointsToNearestCentroid();
+      recomputeCentroids();
+      updateAfterStateChange(false);
+    } else {
+      updateCalculationPanel();
+      draw();
+    }
+  }
+
+  function addPoint(x, y) {
+    state.points.push({ id: createId(), x, y, clusterIndex: null });
+  }
+
+  function removePoint(id) {
+    state.points = state.points.filter((point) => point.id !== id);
+    if (state.selectedPointId === id) {
+      state.selectedPointId = null;
+    }
+    if (state.points.length === 0) {
+      state.centroids = [];
+    }
+    if (state.centroids.length && state.points.length) {
+      assignPointsToNearestCentroid();
+      recomputeCentroids();
+    }
+    updateAfterStateChange(false);
+  }
+
+  function findPointAt(x, y) {
+    return state.points.find((point) => {
+      const distance = Math.hypot(point.x - x, point.y - y);
+      return distance <= POINT_RADIUS + 2;
+    });
+  }
+
+  function resetAssignments() {
+    state.centroids = [];
+    state.points = state.points.map((point) => ({ ...point, clusterIndex: null }));
+    state.iteration = 0;
+    updateSSE(null);
+    updateStatus();
+    updateCalculationPanel();
+  }
+
+  function clearAll() {
+    state.points = [];
+    state.centroids = [];
+    state.iteration = 0;
+    state.selectedPointId = null;
+    updateSSE(null);
+    updateStatus();
+    updateCalculationPanel();
+    draw();
+  }
+
+  function getCanvasPosition(event) {
+    const rect = canvas.getBoundingClientRect();
+    return {
+      x: event.clientX - rect.left,
+      y: event.clientY - rect.top
+    };
+  }
+
+  function initializeCentroids(k) {
+    if (state.points.length < k) {
+      updateSSE(null);
+      return false;
+    }
+
+    const shuffled = [...state.points].sort(() => Math.random() - 0.5);
+    state.centroids = shuffled.slice(0, k).map((point, index) => ({
+      id: createId(),
+      x: point.x,
+      y: point.y,
+      color: CLUSTER_COLORS[index % CLUSTER_COLORS.length]
+    }));
+    state.points = state.points.map((p) => ({ ...p, clusterIndex: null }));
+    return true;
+  }
+
+  function ensureCentroids() {
+    if (state.centroids.length) return true;
+    const initialized = initializeCentroids(state.currentK);
+    if (initialized) {
+      assignPointsToNearestCentroid();
+      recomputeCentroids();
+      updateAfterStateChange();
+    }
+    return initialized;
+  }
+
+  function assignPointsToNearestCentroid() {
+    if (!state.centroids.length) return false;
+    let changed = false;
+    state.points.forEach((point) => {
+      let closestIndex = point.clusterIndex ?? 0;
+      let closestDistance = Number.POSITIVE_INFINITY;
+      state.centroids.forEach((centroid, index) => {
+        const distSq = distanceSquared(point, centroid);
+        if (distSq < closestDistance) {
+          closestDistance = distSq;
+          closestIndex = index;
+        }
+      });
+      if (point.clusterIndex !== closestIndex) {
+        changed = true;
+        point.clusterIndex = closestIndex;
+      }
+    });
+    return changed;
+  }
+
+  function recomputeCentroids() {
+    if (!state.centroids.length) return;
+    state.centroids.forEach((centroid, index) => {
+      const assigned = state.points.filter((point) => point.clusterIndex === index);
+      if (!assigned.length) return;
+      const sum = assigned.reduce(
+        (acc, point) => ({ x: acc.x + point.x, y: acc.y + point.y }),
+        { x: 0, y: 0 }
+      );
+      centroid.x = sum.x / assigned.length;
+      centroid.y = sum.y / assigned.length;
+    });
+  }
+
+  function distanceSquared(a, b) {
+    return (a.x - b.x) ** 2 + (a.y - b.y) ** 2;
+  }
+
+  function computeSSE() {
+    if (!state.centroids.length) return null;
+    return state.points.reduce((sum, point) => {
+      if (point.clusterIndex === null || !state.centroids[point.clusterIndex]) return sum;
+      return sum + distanceSquared(point, state.centroids[point.clusterIndex]);
+    }, 0);
+  }
+
+  function updateSSE(value) {
+    state.sse = value;
+    const display = value === null ? '—' : value.toFixed(2);
+    statusSSE.textContent = display;
+    calculationSSE.textContent = display;
+  }
+
+  function updateStatus() {
+    statusK.textContent = String(state.currentK);
+    statusIter.textContent = String(state.iteration);
+  }
+
+  function updateAfterStateChange(incrementIteration = false, shouldDraw = true) {
+    if (incrementIteration) {
+      state.iteration += 1;
+      updateStatus();
+    } else {
+      updateStatus();
+    }
+    updateSSE(computeSSE());
+    updateCalculationPanel();
+    if (shouldDraw) {
+      draw();
+    }
+  }
+
+  function stepKMeans() {
+    const changed = assignPointsToNearestCentroid();
+    recomputeCentroids();
+    state.iteration += 1;
+    updateStatus();
+    updateSSE(computeSSE());
+    updateCalculationPanel();
+    return changed;
+  }
+
+  function runToConvergence() {
+    if (state.isRunning) return;
+    if (!ensureCentroids()) return;
+
+    state.isRunning = true;
+    toggleRunButton(true);
+    let iterations = 0;
+    const maxIterations = 50;
+
+    const loop = () => {
+      const changed = stepKMeans();
+      draw();
+      iterations += 1;
+      if (!changed || iterations >= maxIterations) {
+        state.isRunning = false;
+        toggleRunButton(false);
+        return;
+      }
+      window.setTimeout(loop, 150);
+    };
+
+    loop();
+  }
+
+  function toggleRunButton(isRunning) {
+    if (!btnRun) return;
+    btnRun.disabled = isRunning;
+    btnRun.textContent = isRunning ? 'Running…' : 'Run to convergence';
+  }
+
+  function draw() {
+    if (!ctx) return;
+    ctx.clearRect(0, 0, canvas.width, canvas.height);
+
+    ctx.strokeStyle = 'rgba(148, 163, 184, 0.6)';
+    ctx.lineWidth = 1;
+    ctx.strokeRect(0.5, 0.5, canvas.width - 1, canvas.height - 1);
+
+    state.points.forEach((point) => {
+      const color =
+        point.clusterIndex === null
+          ? 'rgba(148, 163, 184, 0.8)'
+          : state.centroids[point.clusterIndex]?.color || 'rgba(148, 163, 184, 0.8)';
+
+      ctx.beginPath();
+      ctx.arc(point.x, point.y, POINT_RADIUS, 0, Math.PI * 2);
+      ctx.fillStyle = color;
+      ctx.fill();
+      if (state.selectedPointId === point.id) {
+        ctx.strokeStyle = '#0ea5e9';
+        ctx.lineWidth = 2;
+        ctx.stroke();
+      }
+    });
+
+    state.centroids.forEach((centroid, index) => {
+      ctx.fillStyle = centroid.color;
+      ctx.strokeStyle = '#0f172a';
+      ctx.lineWidth = 2;
+      ctx.beginPath();
+      ctx.rect(
+        centroid.x - CENTROID_RADIUS,
+        centroid.y - CENTROID_RADIUS,
+        CENTROID_RADIUS * 2,
+        CENTROID_RADIUS * 2
+      );
+      ctx.fill();
+      ctx.stroke();
+
+      ctx.fillStyle = '#fff';
+      ctx.font = '12px Inter, system-ui, sans-serif';
+      ctx.textAlign = 'center';
+      ctx.textBaseline = 'middle';
+      ctx.fillText(String(index + 1), centroid.x, centroid.y);
+    });
+  }
+
+  function updateCalculationPanel() {
+    const hasCentroids = state.centroids.length > 0;
+    const selectedPoint = state.points.find((p) => p.id === state.selectedPointId);
+
+    if (!selectedPoint || !hasCentroids) {
+      selectedPointLabel.textContent = 'none';
+      if (distanceTable) {
+        distanceTable.innerHTML = '';
+      }
+      calculationSSE.textContent = state.sse === null ? '—' : state.sse.toFixed(2);
+      return;
+    }
+
+    selectedPointLabel.textContent = `(${selectedPoint.x.toFixed(1)}, ${selectedPoint.y.toFixed(1)})`;
+
+    let nearestIndex = 0;
+    let nearestDistance = Number.POSITIVE_INFINITY;
+
+    state.centroids.forEach((centroid, index) => {
+      const dist = Math.sqrt(distanceSquared(selectedPoint, centroid));
+      if (dist < nearestDistance) {
+        nearestDistance = dist;
+        nearestIndex = index;
+      }
+    });
+
+    if (distanceTable) {
+      distanceTable.innerHTML = '';
+      state.centroids.forEach((centroid, index) => {
+        const row = document.createElement('tr');
+        const dist = Math.sqrt(distanceSquared(selectedPoint, centroid));
+
+        const cells = [
+          `C${index + 1}`,
+          `(${centroid.x.toFixed(1)}, ${centroid.y.toFixed(1)})`,
+          dist.toFixed(2),
+          index === nearestIndex ? 'Yes' : 'No'
+        ];
+
+        cells.forEach((value, cellIndex) => {
+          const cell = document.createElement('td');
+          cell.textContent = value;
+          if (cellIndex === cells.length - 1 && index === nearestIndex) {
+            cell.classList.add('ml-table--nearest');
+          }
+          row.appendChild(cell);
+        });
+
+        distanceTable.appendChild(row);
+      });
+    }
+
+    calculationSSE.textContent = state.sse === null ? '—' : state.sse.toFixed(2);
+  }
+
+  return { init };
+})();
+
+document.addEventListener('DOMContentLoaded', () => {
+  MLPlayground.init();
+});

--- a/endless-depths.html
+++ b/endless-depths.html
@@ -47,6 +47,7 @@
               </ul>
             </li>
             <li><a class="nav-pill" href="ml-game.html">Transformer Lab</a></li>
+            <li><a class="nav-pill" href="ml-playground.html">ML Playground</a></li>
             <li><a class="nav-pill" href="endless-depths.html" aria-current="page">Endless Depths</a></li>
           </ul>
           <div class="nav-actions">

--- a/index.html
+++ b/index.html
@@ -61,6 +61,7 @@
               </ul>
             </li>
             <li><a class="nav-pill" href="ml-game.html">Transformer Lab</a></li>
+            <li><a class="nav-pill" href="ml-playground.html">ML Playground</a></li>
             <li><a class="nav-pill" href="endless-depths.html">Endless Depths</a></li>
           </ul>
           <div class="nav-actions">

--- a/ml-game.html
+++ b/ml-game.html
@@ -51,6 +51,7 @@
               </ul>
             </li>
             <li><a class="nav-pill" href="ml-game.html" aria-current="page">Transformer Lab</a></li>
+            <li><a class="nav-pill" href="ml-playground.html">ML Playground</a></li>
             <li><a class="nav-pill" href="endless-depths.html">Endless Depths</a></li>
           </ul>
           <div class="nav-actions">

--- a/ml-playground.html
+++ b/ml-playground.html
@@ -1,0 +1,170 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <meta
+      name="description"
+      content="Experiment with K-means clustering by adding, dragging, and grouping points on an interactive canvas."
+    />
+    <title>ML Playground · Ka Ming Lui</title>
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&family=Fira+Code:wght@400;500&display=swap"
+      rel="stylesheet"
+    />
+    <link rel="stylesheet" href="assets/css/style.css" />
+  </head>
+  <body class="theme-light">
+    <header class="site-header" id="top">
+      <div class="container">
+        <nav class="nav" aria-label="Primary">
+          <a class="logo" href="index.html#hero">Ka Ming Lui</a>
+          <button class="nav-toggle" type="button" aria-expanded="false" aria-controls="primary-navigation">
+            <span class="nav-toggle__bar"></span>
+            <span class="nav-toggle__bar"></span>
+            <span class="nav-toggle__bar"></span>
+            <span class="sr-only">Toggle navigation</span>
+          </button>
+          <ul class="nav-links" id="primary-navigation" data-visible="false">
+            <li class="nav-item nav-item--dropdown">
+              <button
+                class="nav-dropdown-toggle nav-pill"
+                type="button"
+                aria-expanded="false"
+                aria-controls="section-menu"
+              >
+                Sections
+                <svg class="nav-dropdown__icon" aria-hidden="true" focusable="false" viewBox="0 0 12 12">
+                  <path
+                    d="M2.47 4.47a.75.75 0 0 1 1.06 0L6 6.94l2.47-2.47a.75.75 0 0 1 1.06 1.06l-3 3a.75.75 0 0 1-1.06 0l-3-3a.75.75 0 0 1 0-1.06Z"
+                  />
+                </svg>
+              </button>
+              <ul class="nav-dropdown-menu" id="section-menu" hidden>
+                <li><a href="index.html#about">About</a></li>
+                <li><a href="index.html#learning">Learning</a></li>
+                <li><a href="index.html#posts">Posts</a></li>
+                <li><a href="index.html#projects">Projects</a></li>
+                <li><a href="index.html#experience">Experience</a></li>
+                <li><a href="index.html#education">Education</a></li>
+                <li><a href="index.html#contact">Contact</a></li>
+              </ul>
+            </li>
+            <li><a class="nav-pill" href="ml-game.html">Transformer Lab</a></li>
+            <li><a class="nav-pill" href="ml-playground.html" aria-current="page">ML Playground</a></li>
+            <li><a class="nav-pill" href="endless-depths.html">Endless Depths</a></li>
+          </ul>
+          <div class="nav-actions">
+            <button class="theme-toggle" type="button" aria-label="Toggle color theme">
+              <span aria-hidden="true">🌙</span>
+            </button>
+          </div>
+        </nav>
+      </div>
+    </header>
+
+    <main class="container ml-playground-page">
+      <header class="ml-playground__header">
+        <p class="card__eyebrow">Interactive clustering</p>
+        <h1>ML Playground — K-Means Clustering Explorer</h1>
+        <p class="ml-playground__lead">
+          Add, delete, and drag data points to see how K-means groups them. Adjust <em>k</em>, step through each iteration, or
+          let the algorithm run to convergence while you watch the objective change.
+        </p>
+      </header>
+
+      <section class="ml-toolbar">
+        <div class="field-group">
+          <label for="algorithm-select">Algorithm</label>
+          <select id="algorithm-select">
+            <option value="kmeans" selected>K-means (Lloyd's algorithm)</option>
+          </select>
+        </div>
+      </section>
+
+      <section class="ml-playground">
+        <div class="ml-playground-main">
+          <canvas id="kmeans-canvas" width="720" height="480" aria-label="K-means playground canvas"></canvas>
+
+          <div class="ml-controls">
+            <label for="k-input">Number of clusters (k)</label>
+            <input id="k-input" type="number" min="1" max="8" value="3" />
+
+            <button id="btn-init-centroids" type="button">Initialize centroids</button>
+            <button id="btn-step" type="button">Step (assign &amp; update)</button>
+            <button id="btn-run" type="button">Run to convergence</button>
+            <button id="btn-reset-clustering" type="button">Reset clustering</button>
+            <button id="btn-clear-points" type="button">Clear all points</button>
+
+            <p id="kmeans-status">
+              Clusters: <span id="status-k">3</span> ·
+              Iteration: <span id="status-iter">0</span> ·
+              SSE: <span id="status-sse">—</span>
+            </p>
+
+            <p class="ml-hint">
+              Hint: click empty canvas to add a point. Shift+click a point to delete it. Click and drag a point to move it.
+            </p>
+          </div>
+        </div>
+
+        <aside class="ml-sidebar">
+          <button id="btn-toggle-calculations" type="button" aria-expanded="false">Show calculation process</button>
+
+          <div id="calculation-panel" hidden>
+            <h2>Calculation details</h2>
+            <p>
+              K-means alternates between assigning each point to the nearest centroid and recomputing each centroid as the mean
+              of its assigned points.
+            </p>
+
+            <p>
+              Selected point:
+              <span id="selected-point-label">none</span>
+            </p>
+
+            <table id="distance-table">
+              <thead>
+                <tr>
+                  <th>Centroid</th>
+                  <th>Coordinates</th>
+                  <th>Distance to point</th>
+                  <th>Is nearest?</th>
+                </tr>
+              </thead>
+              <tbody></tbody>
+            </table>
+
+            <p>
+              Objective (sum of squared errors):
+              <strong id="calculation-sse">—</strong>
+            </p>
+          </div>
+        </aside>
+      </section>
+    </main>
+
+    <footer class="site-footer">
+      <div class="container footer__layout">
+        <div>
+          <h2>Want to explore more ML demos?</h2>
+          <p>Try the transformer lab or reach out to share your favorite visualization ideas.</p>
+          <div class="footer__actions">
+            <a class="button button--primary" href="ml-game.html">Visit Transformer Lab</a>
+            <a class="button button--ghost" href="mailto:contact@kaminglui.com">Email Ka-Ming</a>
+          </div>
+        </div>
+        <div class="footer__meta">
+          <p>Curious how this playground works? Inspect the source on GitHub to tweak the algorithm.</p>
+          <p>&copy; <span id="year"></span> Ka Ming Lui. Built with accessibility and performance in mind.</p>
+        </div>
+      </div>
+      <a class="back-to-top" href="#top">Back to top</a>
+    </footer>
+
+    <script type="module" src="assets/js/main.js"></script>
+    <script type="module" src="assets/js/ml-playground.js"></script>
+  </body>
+</html>


### PR DESCRIPTION
## Summary
- add an ML Playground page with canvas-based point interactions and a K-means walkthrough panel
- implement the K-means clustering logic, controls, and SSE reporting in a dedicated module
- update navigation, shared styling, and main script guards to support the new page

## Testing
- node --check assets/js/main.js
- node --check assets/js/content.js
- node --check assets/js/ml-playground.js

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6923c68b140883279c1dc1edd88275f2)