### PR TITLE
Improve ML playground calculation details

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -903,6 +903,20 @@ body.theme-dark .project-card {
   margin: 0;
 }
 
+.calculation-hint {
+  padding: 0.75rem 0.85rem;
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-sm);
+  background: linear-gradient(135deg, rgba(59, 130, 246, 0.08), rgba(34, 197, 94, 0.05));
+  display: grid;
+  gap: 0.35rem;
+}
+
+.calculation-hint__note {
+  margin: 0;
+  color: var(--color-muted);
+}
+
 .ml-playground .card__eyebrow {
   margin: 0;
 }

--- a/ml-playground.html
+++ b/ml-playground.html
@@ -174,9 +174,24 @@
                 of its assigned points.
               </p>
 
+              <div class="calculation-hint">
+                <p><strong>What's shown here?</strong></p>
+                <ul>
+                  <li><strong>Centroid</strong> is the current group center the point is comparing against.</li>
+                  <li><strong>Distance</strong> is how far the point is from that centroid (smaller is closer).</li>
+                  <li><strong>Objective</strong> is the running total of squared distances for <em>all</em> points (lower is better).</li>
+                </ul>
+                <p class="calculation-hint__note">Tip: click any point on the canvas to focus it here. Dragging a point updates the table in real time.</p>
+              </div>
+
               <p>
                 Selected point:
                 <span id="selected-point-label">none</span>
+              </p>
+
+              <p>
+                Cluster assignment:
+                <span id="selected-cluster-label">—</span>
               </p>
 
               <table id="distance-table">


### PR DESCRIPTION
## Summary
- add explanatory hints and cluster assignment display to the calculation details panel
- ensure a point is always selected so distance and SSE data populate reliably, including after adding or resetting points
- style the calculation help block to make the process easier to follow

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6923e0eae0288327be1124b79843e5b6)