### PR TITLE
Improve ML playground usability and layout

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -748,6 +748,42 @@ body.theme-dark .project-card {
   font-weight: 600;
 }
 
+.ml-tablist {
+  display: flex;
+  gap: 0.75rem;
+  align-items: center;
+  justify-content: center;
+  flex-wrap: wrap;
+}
+
+.ml-tab {
+  padding: 0.65rem 1.1rem;
+  border-radius: 999px;
+  border: 1px solid var(--color-border);
+  background: var(--color-surface);
+  box-shadow: var(--shadow-sm);
+  cursor: pointer;
+  font-weight: 700;
+  color: var(--color-muted);
+  transition: border-color 150ms ease, box-shadow 150ms ease, transform 150ms ease, color 150ms ease;
+}
+
+.ml-tab.is-active {
+  color: var(--color-accent);
+  border-color: var(--color-accent);
+  box-shadow: 0 10px 30px rgba(59, 130, 246, 0.15);
+  transform: translateY(-1px);
+}
+
+.ml-tab:focus-visible {
+  outline: 2px solid var(--color-accent);
+  outline-offset: 2px;
+}
+
+.ml-tabpanel {
+  width: 100%;
+}
+
 .ml-guide-cards {
   display: grid;
   gap: 1rem;
@@ -805,6 +841,8 @@ body.theme-dark .project-card {
     radial-gradient(circle at 80% 40%, rgba(22, 163, 74, 0.04), transparent),
     var(--color-surface);
   box-shadow: var(--shadow-sm);
+  touch-action: none;
+  cursor: crosshair;
 }
 
 .ml-controls {

--- a/assets/js/ml-playground.js
+++ b/assets/js/ml-playground.js
@@ -1,5 +1,6 @@
 const MLPlayground = (() => {
-  const POINT_RADIUS = 7;
+  const POINT_RADIUS = 9;
+  const HIT_RADIUS = 14;
   const CENTROID_RADIUS = 10;
   const CLUSTER_COLORS = [
     '#3b82f6',
@@ -20,11 +21,11 @@ const MLPlayground = (() => {
   let btnRun;
   let btnReset;
   let btnClear;
-  let btnTogglePanel;
+  let tabs;
+  let tabPanels;
   let statusK;
   let statusIter;
   let statusSSE;
-  let calculationPanel;
   let calculationSSE;
   let distanceTable;
   let selectedPointLabel;
@@ -55,11 +56,11 @@ const MLPlayground = (() => {
     btnRun = document.getElementById('btn-run');
     btnReset = document.getElementById('btn-reset-clustering');
     btnClear = document.getElementById('btn-clear-points');
-    btnTogglePanel = document.getElementById('btn-toggle-calculations');
+    tabs = Array.from(document.querySelectorAll('.ml-tab'));
+    tabPanels = Array.from(document.querySelectorAll('.ml-tabpanel'));
     statusK = document.getElementById('status-k');
     statusIter = document.getElementById('status-iter');
     statusSSE = document.getElementById('status-sse');
-    calculationPanel = document.getElementById('calculation-panel');
     calculationSSE = document.getElementById('calculation-sse');
     distanceTable = document.querySelector('#distance-table tbody');
     selectedPointLabel = document.getElementById('selected-point-label');
@@ -69,6 +70,7 @@ const MLPlayground = (() => {
 
     state.currentK = clampK(Number(kInput?.value) || 3);
     updateStatus();
+    setupTabs();
     attachEvents();
     draw();
   }
@@ -77,11 +79,47 @@ const MLPlayground = (() => {
     return Math.min(8, Math.max(1, Math.round(value)));
   }
 
+  function setupTabs() {
+    if (!tabs?.length || !tabPanels?.length) return;
+
+    const activateTab = (tab) => {
+      const targetId = tab.getAttribute('aria-controls');
+      tabs.forEach((btn) => {
+        const isActive = btn === tab;
+        btn.classList.toggle('is-active', isActive);
+        btn.setAttribute('aria-selected', String(isActive));
+        btn.tabIndex = isActive ? 0 : -1;
+      });
+
+      tabPanels.forEach((panel) => {
+        const shouldShow = panel.id === targetId;
+        panel.hidden = !shouldShow;
+      });
+
+      if (targetId === 'panel-calculations') {
+        updateCalculationPanel();
+      }
+    };
+
+    tabs.forEach((tab) => {
+      tab.addEventListener('click', () => activateTab(tab));
+      tab.addEventListener('keydown', (event) => {
+        if (event.key === 'Enter' || event.key === ' ') {
+          event.preventDefault();
+          activateTab(tab);
+        }
+      });
+    });
+
+    const initialTab = tabs.find((tab) => tab.classList.contains('is-active')) ?? tabs[0];
+    if (initialTab) activateTab(initialTab);
+  }
+
   function attachEvents() {
     canvas.addEventListener('mousedown', handleCanvasMouseDown);
     canvas.addEventListener('mousemove', handleCanvasMouseMove);
     canvas.addEventListener('mouseup', handleCanvasMouseUp);
-    canvas.addEventListener('mouseleave', handleCanvasMouseUp);
+    canvas.addEventListener('mouseleave', handleCanvasMouseLeave);
 
     kInput?.addEventListener('change', () => {
       const newK = clampK(Number(kInput.value));
@@ -130,16 +168,6 @@ const MLPlayground = (() => {
     btnClear?.addEventListener('click', () => {
       clearAll();
     });
-
-    btnTogglePanel?.addEventListener('click', () => {
-      const isExpanded = btnTogglePanel.getAttribute('aria-expanded') === 'true';
-      btnTogglePanel.setAttribute('aria-expanded', String(!isExpanded));
-      btnTogglePanel.textContent = isExpanded ? 'Show calculation process' : 'Hide calculation process';
-      if (calculationPanel) {
-        calculationPanel.hidden = isExpanded;
-      }
-      updateCalculationPanel();
-    });
   }
 
   function handleCanvasMouseDown(event) {
@@ -154,6 +182,7 @@ const MLPlayground = (() => {
     if (existingPoint) {
       state.selectedPointId = existingPoint.id;
       state.dragPointId = existingPoint.id;
+      updateCanvasCursor(true);
       draw();
       updateCalculationPanel();
       return;
@@ -172,8 +201,10 @@ const MLPlayground = (() => {
   }
 
   function handleCanvasMouseMove(event) {
-    if (!state.dragPointId) return;
     const position = getCanvasPosition(event);
+    const hoveredPoint = findPointAt(position.x, position.y);
+    updateCanvasCursor(Boolean(hoveredPoint) || Boolean(state.dragPointId));
+    if (!state.dragPointId) return;
     const point = state.points.find((p) => p.id === state.dragPointId);
     if (point) {
       point.x = position.x;
@@ -185,6 +216,7 @@ const MLPlayground = (() => {
   function handleCanvasMouseUp() {
     if (!state.dragPointId) return;
     state.dragPointId = null;
+    updateCanvasCursor(false);
     if (state.centroids.length) {
       assignPointsToNearestCentroid();
       recomputeCentroids();
@@ -193,6 +225,13 @@ const MLPlayground = (() => {
       updateCalculationPanel();
       draw();
     }
+  }
+
+  function handleCanvasMouseLeave() {
+    if (state.dragPointId) {
+      handleCanvasMouseUp();
+    }
+    updateCanvasCursor(false);
   }
 
   function addPoint(x, y) {
@@ -220,7 +259,7 @@ const MLPlayground = (() => {
   function findPointAt(x, y) {
     return state.points.find((point) => {
       const distance = Math.hypot(point.x - x, point.y - y);
-      return distance <= POINT_RADIUS + 2;
+      return distance <= HIT_RADIUS;
     });
   }
 
@@ -251,6 +290,15 @@ const MLPlayground = (() => {
       x: event.clientX - rect.left,
       y: event.clientY - rect.top
     };
+  }
+
+  function updateCanvasCursor(isHoveringPoint) {
+    if (!canvas) return;
+    if (state.dragPointId) {
+      canvas.style.cursor = 'grabbing';
+    } else {
+      canvas.style.cursor = isHoveringPoint ? 'grab' : 'crosshair';
+    }
   }
 
   function initializeCentroids(k) {

--- a/ml-playground.html
+++ b/ml-playground.html
@@ -89,129 +89,144 @@
           </div>
         </section>
 
-        <section class="ml-guide-cards" aria-label="Tips for exploring">
-          <article class="ml-guide-card">
-            <p class="ml-guide-card__label">Step-by-step</p>
-            <h2 class="ml-guide-card__title">Watch the algorithm converge</h2>
-            <p class="ml-guide-card__body">
-              Use <strong>Step</strong> to perform one assign/update cycle and observe how centroids migrate. Switch to
-              <strong>Run to convergence</strong> when you are ready to let the loop finish automatically.
-            </p>
-          </article>
-          <article class="ml-guide-card">
-            <p class="ml-guide-card__label">Hands-on</p>
-            <h2 class="ml-guide-card__title">Drag and reshape clusters</h2>
-            <p class="ml-guide-card__body">
-              Drag any point to a new position or <strong>Shift+click</strong> to remove it. The assignments and SSE update as
-              soon as you release the mouse.
-            </p>
-          </article>
-        </section>
+        <div class="ml-tablist" role="tablist" aria-label="ML playground sections">
+          <button class="ml-tab is-active" role="tab" aria-selected="true" aria-controls="panel-playground" id="tab-playground">
+            Playground
+          </button>
+          <button class="ml-tab" role="tab" aria-selected="false" aria-controls="panel-calculations" id="tab-calculations">
+            Calculations
+          </button>
+          <button class="ml-tab" role="tab" aria-selected="false" aria-controls="panel-guide" id="tab-guide">
+            Guide
+          </button>
+        </div>
 
-        <section class="ml-playground">
-          <div class="ml-playground-main">
-            <canvas
-              id="kmeans-canvas"
-              width="720"
-              height="480"
-              aria-label="K-means playground canvas"
-              title="Click to add a point, drag to move it, or Shift+click to remove. Initialize centroids to start clustering."
-            ></canvas>
+        <section class="ml-tabpanel" id="panel-playground" role="tabpanel" aria-labelledby="tab-playground">
+          <div class="ml-playground">
+            <div class="ml-playground-main">
+              <canvas
+                id="kmeans-canvas"
+                width="720"
+                height="480"
+                aria-label="K-means playground canvas"
+                title="Click to add a point, drag to move it, or Shift+click to remove. Initialize centroids to start clustering."
+              ></canvas>
 
-            <div class="ml-controls">
-              <label for="k-input">Number of clusters (k)</label>
-              <input
-                id="k-input"
-                type="number"
-                min="1"
-                max="8"
-                value="3"
-                title="Choose how many clusters K-means should find (1 to 8)"
-              />
+              <div class="ml-controls">
+                <label for="k-input">Number of clusters (k)</label>
+                <input
+                  id="k-input"
+                  type="number"
+                  min="1"
+                  max="8"
+                  value="3"
+                  title="Choose how many clusters K-means should find (1 to 8)"
+                />
 
-              <button id="btn-init-centroids" type="button" title="Pick k random points as starting centroids and assign clusters">
-                Initialize centroids
-              </button>
-              <button id="btn-step" type="button" title="Run one iteration: assign points, then update centroids">
-                Step (assign &amp; update)
-              </button>
-              <button id="btn-run" type="button" title="Keep iterating until assignments stop changing or a safety cap is reached">
-                Run to convergence
-              </button>
-              <button id="btn-reset-clustering" type="button" title="Remove centroids and assignments but keep your points on the canvas">
-                Reset clustering
-              </button>
-              <button id="btn-clear-points" type="button" title="Remove all points and centroids to start fresh">
-                Clear all points
-              </button>
+                <button id="btn-init-centroids" type="button" title="Pick k random points as starting centroids and assign clusters">
+                  Initialize centroids
+                </button>
+                <button id="btn-step" type="button" title="Run one iteration: assign points, then update centroids">
+                  Step (assign &amp; update)
+                </button>
+                <button id="btn-run" type="button" title="Keep iterating until assignments stop changing or a safety cap is reached">
+                  Run to convergence
+                </button>
+                <button id="btn-reset-clustering" type="button" title="Remove centroids and assignments but keep your points on the canvas">
+                  Reset clustering
+                </button>
+                <button id="btn-clear-points" type="button" title="Remove all points and centroids to start fresh">
+                  Clear all points
+                </button>
 
-              <p id="kmeans-status">
-                Clusters: <span id="status-k">3</span> ·
-                Iteration: <span id="status-iter">0</span> ·
-                SSE: <span id="status-sse">—</span>
-              </p>
+                <p id="kmeans-status">
+                  Clusters: <span id="status-k">3</span> ·
+                  Iteration: <span id="status-iter">0</span> ·
+                  SSE: <span id="status-sse">—</span>
+                </p>
 
-              <p class="ml-hint">
-                Hint: click empty canvas to add a point. Shift+click a point to delete it. Click and drag a point to move it.
-              </p>
+                <p class="ml-hint">
+                  Hint: click the canvas to add a point. Shift+click a point to delete it. Drag any point to move it.
+                </p>
+              </div>
             </div>
           </div>
+        </section>
 
+        <section class="ml-tabpanel" id="panel-calculations" role="tabpanel" aria-labelledby="tab-calculations" hidden>
           <aside class="ml-sidebar">
-            <button
-              id="btn-toggle-calculations"
-              type="button"
-              aria-expanded="false"
-              title="Toggle a breakdown of per-point distances and the current SSE"
-            >
-              Show calculation process
-            </button>
+            <h2>Calculation details</h2>
+            <p>
+              K-means alternates between assigning each point to the nearest centroid and recomputing each centroid as the mean
+              of its assigned points.
+            </p>
 
-            <div id="calculation-panel" hidden>
-              <h2>Calculation details</h2>
-              <p>
-                K-means alternates between assigning each point to the nearest centroid and recomputing each centroid as the mean
-                of its assigned points.
-              </p>
-
-              <div class="calculation-hint">
-                <p><strong>What's shown here?</strong></p>
-                <ul>
-                  <li><strong>Centroid</strong> is the current group center the point is comparing against.</li>
-                  <li><strong>Distance</strong> is how far the point is from that centroid (smaller is closer).</li>
-                  <li><strong>Objective</strong> is the running total of squared distances for <em>all</em> points (lower is better).</li>
-                </ul>
-                <p class="calculation-hint__note">Tip: click any point on the canvas to focus it here. Dragging a point updates the table in real time.</p>
-              </div>
-
-              <p>
-                Selected point:
-                <span id="selected-point-label">none</span>
-              </p>
-
-              <p>
-                Cluster assignment:
-                <span id="selected-cluster-label">—</span>
-              </p>
-
-              <table id="distance-table">
-                <thead>
-                  <tr>
-                    <th>Centroid</th>
-                    <th>Coordinates</th>
-                    <th>Distance to point</th>
-                    <th>Is nearest?</th>
-                  </tr>
-                </thead>
-                <tbody></tbody>
-              </table>
-
-              <p>
-                Objective (sum of squared errors):
-                <strong id="calculation-sse">—</strong>
-              </p>
+            <div class="calculation-hint">
+              <p><strong>What's shown here?</strong></p>
+              <ul>
+                <li><strong>Centroid</strong> is the current group center the point is comparing against.</li>
+                <li><strong>Distance</strong> is how far the point is from that centroid (smaller is closer).</li>
+                <li><strong>Objective</strong> is the running total of squared distances for <em>all</em> points (lower is better).</li>
+              </ul>
+              <p class="calculation-hint__note">Tip: click any point on the canvas to focus it here. Dragging a point updates the table in real time.</p>
             </div>
+
+            <p>
+              Selected point:
+              <span id="selected-point-label">none</span>
+            </p>
+
+            <p>
+              Cluster assignment:
+              <span id="selected-cluster-label">—</span>
+            </p>
+
+            <table id="distance-table">
+              <thead>
+                <tr>
+                  <th>Centroid</th>
+                  <th>Coordinates</th>
+                  <th>Distance to point</th>
+                  <th>Is nearest?</th>
+                </tr>
+              </thead>
+              <tbody></tbody>
+            </table>
+
+            <p>
+              Objective (sum of squared errors):
+              <strong id="calculation-sse">—</strong>
+            </p>
           </aside>
+        </section>
+
+        <section class="ml-tabpanel" id="panel-guide" role="tabpanel" aria-labelledby="tab-guide" hidden>
+          <div class="ml-guide-cards" aria-label="Tips for exploring">
+            <article class="ml-guide-card">
+              <p class="ml-guide-card__label">Step-by-step</p>
+              <h2 class="ml-guide-card__title">Watch the algorithm converge</h2>
+              <p class="ml-guide-card__body">
+                Use <strong>Step</strong> to perform one assign/update cycle and observe how centroids migrate. Switch to
+                <strong>Run to convergence</strong> when you're ready to let the loop finish automatically.
+              </p>
+            </article>
+            <article class="ml-guide-card">
+              <p class="ml-guide-card__label">Hands-on</p>
+              <h2 class="ml-guide-card__title">Drag and reshape clusters</h2>
+              <p class="ml-guide-card__body">
+                Drag any point to a new position or <strong>Shift+click</strong> to remove it. The assignments and SSE update as
+                soon as you release the mouse.
+              </p>
+            </article>
+            <article class="ml-guide-card">
+              <p class="ml-guide-card__label">Reset fast</p>
+              <h2 class="ml-guide-card__title">Try a new configuration</h2>
+              <p class="ml-guide-card__body">
+                <strong>Reset clustering</strong> keeps your points but clears assignments. <strong>Clear all</strong> wipes the
+                board so you can design a fresh dataset.
+              </p>
+            </article>
+          </div>
         </section>
       </div>
     </main>


### PR DESCRIPTION
## Summary
- reorganized the ML playground content into tabs so only one area shows at a time, keeping the page compact
- enlarged point hit areas and added cursor cues to make selecting and dragging dots smoother
- updated styles to support the tabbed layout and improved canvas touch handling

## Testing
- npm run dev:server (manually stopped after verifying the server started)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6923e3afb6908327983619038a0a6615)