### PR TITLE
Add analog circuit lab simulator

### DIFF
--- a/circuit-sim/index.html
+++ b/circuit-sim/index.html
@@ -1,0 +1,63 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Analog Circuit Lab</title>
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600&family=Fira+Code:wght@400;600&display=swap"
+      rel="stylesheet"
+    />
+    <link rel="stylesheet" href="style.css" />
+  </head>
+  <body>
+    <header>
+      <h1>Analog Circuit Lab</h1>
+      <nav class="nav-links">
+        <a href="../index.html">Home</a>
+        <a href="https://github.com/kaminglui" target="_blank" rel="noreferrer">GitHub</a>
+      </nav>
+    </header>
+    <main>
+      <div class="canvas-wrapper">
+        <div class="toolbar" id="toolbar"></div>
+        <canvas id="schematic" width="900" height="500" aria-label="Schematic canvas"></canvas>
+      </div>
+      <div class="sidebar">
+        <section class="panel" id="sim-panel">
+          <h3>Simulation</h3>
+          <div class="toolbar" id="sim-controls"></div>
+          <div class="property-grid">
+            <label>Time/Div</label>
+            <input type="number" id="time-div" value="1e-3" step="1e-3" />
+            <label>dt</label>
+            <input type="number" id="dt" value="1e-4" step="1e-4" />
+          </div>
+        </section>
+        <section class="panel">
+          <h3>Oscilloscope</h3>
+          <canvas id="scope" width="420" height="220"></canvas>
+          <div class="property-grid">
+            <label>CH1 Node</label>
+            <select id="ch1-node"></select>
+            <label>CH2 Node</label>
+            <select id="ch2-node"></select>
+            <label>Volts/Div</label>
+            <input type="number" id="v-div" value="1" step="0.5" />
+          </div>
+        </section>
+        <section class="panel" id="properties">
+          <h3>Properties</h3>
+          <div id="prop-content">Select a component.</div>
+        </section>
+        <section class="panel">
+          <h3>Log</h3>
+          <div class="log" id="log"></div>
+        </section>
+      </div>
+    </main>
+    <script type="module" src="./src/main.js"></script>
+  </body>
+</html>

--- a/circuit-sim/src/main.js
+++ b/circuit-sim/src/main.js
@@ -1,0 +1,112 @@
+/**
+ * Entry point wiring together schematic editor, solver, and scope.
+ */
+import { Schematic } from './ui/schematic.js';
+import { Scope } from './ui/scope.js';
+import { renderToolbar, renderSimControls, updateProperties } from './ui/panels.js';
+import { buildSolverFromNetlist } from './sim/netlist.js';
+
+const logEl = document.getElementById('log');
+function log(msg) {
+  const line = document.createElement('div');
+  line.textContent = `[${new Date().toLocaleTimeString()}] ${msg}`;
+  logEl.appendChild(line);
+  logEl.scrollTop = logEl.scrollHeight;
+}
+
+const schematicCanvas = document.getElementById('schematic');
+const schematic = new Schematic(schematicCanvas, log);
+const scope = new Scope(document.getElementById('scope'));
+let running = false;
+let solver = null;
+
+renderToolbar(document.getElementById('toolbar'), schematic, (tool) => {
+  log(`Tool: ${tool}`);
+});
+
+renderSimControls(document.getElementById('sim-controls'), {
+  dc: () => runDC(),
+  run: () => startTransient(),
+  stop: () => stopSim()
+});
+
+schematicCanvas.addEventListener('click', () => {
+  updateProperties(document.getElementById('prop-content'), schematic.selected, () => {});
+});
+
+function populateNodeSelectors(nodes) {
+  const ch1 = document.getElementById('ch1-node');
+  const ch2 = document.getElementById('ch2-node');
+  [ch1, ch2].forEach((sel) => {
+    sel.innerHTML = '';
+    nodes.forEach((n) => {
+      const opt = document.createElement('option');
+      opt.value = n.id;
+      opt.textContent = `${n.id}: ${n.name}`;
+      sel.appendChild(opt);
+    });
+  });
+  ch1.value = 1;
+  ch2.value = 2;
+}
+
+function defaultCircuit() {
+  const vin = schematic.addComponent('VAC', { x: 120, y: 200 }, { vPeak: 1, freq: 1e3 });
+  const r1 = schematic.addComponent('R', { x: 220, y: 200 }, { R: 1000 });
+  const c1 = schematic.addComponent('C', { x: 320, y: 200 }, { C: 1e-6 });
+  const gnd = schematic.addComponent('GND', { x: 120, y: 260 });
+  schematic.wires.push(
+    { points: [vin.pins[0], r1.pins[0]] },
+    { points: [r1.pins[1], c1.pins[0]] },
+    { points: [c1.pins[1], gnd.pins[0]] },
+    { points: [vin.pins[1], gnd.pins[0]] }
+  );
+  schematic.draw();
+}
+
+defaultCircuit();
+
+function buildSolver() {
+  const netlist = schematic.currentNetlist();
+  populateNodeSelectors(netlist.nodes);
+  solver = buildSolverFromNetlist(netlist);
+  return solver;
+}
+
+function runDC() {
+  buildSolver();
+  const result = solver.runDC();
+  schematic.updateNodeVoltages(solver);
+  log(`DC operating point ${result.converged ? 'converged' : 'failed'} in ${result.iterations} iterations.`);
+}
+
+function startTransient() {
+  if (!solver) buildSolver();
+  running = true;
+  loop();
+}
+
+function stopSim() {
+  running = false;
+}
+
+function loop() {
+  if (!running) return;
+  const dt = parseFloat(document.getElementById('dt').value || '1e-4');
+  const tDiv = parseFloat(document.getElementById('time-div').value || '1e-3');
+  scope.setScales({ vDiv: parseFloat(document.getElementById('v-div').value || '1'), tDiv });
+  solver.dt = dt;
+  const ok = solver.stepTransient(solver.time);
+  if (!ok) log('Transient step failed to converge.');
+  const ch1 = parseInt(document.getElementById('ch1-node').value || '1', 10);
+  const ch2 = parseInt(document.getElementById('ch2-node').value || '0', 10);
+  const v1 = ch1 === 0 ? 0 : solver.solution[ch1 - 1] || 0;
+  const v2 = ch2 === 0 ? 0 : solver.solution[ch2 - 1] || 0;
+  scope.sample(solver.time, v1, v2);
+  schematic.updateNodeVoltages(solver);
+  scope.draw();
+  requestAnimationFrame(loop);
+}
+
+runDC();
+scope.draw();

--- a/circuit-sim/src/sim/devices.js
+++ b/circuit-sim/src/sim/devices.js
@@ -1,0 +1,313 @@
+/**
+ * Device models and stamping helpers for the MNA solver.
+ * Each device implements a simple interface for DC and transient analysis.
+ */
+import { MOS_MODEL_DEFAULTS } from './mosDefaults.js';
+
+function nIndex(node) {
+  return node > 0 ? node - 1 : null;
+}
+
+export class Device {
+  constructor() {
+    this.extraVars = 0;
+    this.branchIndex = null;
+  }
+
+  assignExtra(startIndex) {
+    if (this.extraVars === 0) return startIndex;
+    this.branchIndex = startIndex;
+    return startIndex + this.extraVars;
+  }
+
+  getNodeIndices() {
+    return [];
+  }
+}
+
+export class Resistor extends Device {
+  constructor(n1, n2, R) {
+    super();
+    this.n1 = n1;
+    this.n2 = n2;
+    this.R = Math.max(1e-12, R);
+  }
+
+  stampDC(G) {
+    const g = 1 / this.R;
+    const a = nIndex(this.n1);
+    const b = nIndex(this.n2);
+    if (a !== null) G[a][a] += g;
+    if (b !== null) G[b][b] += g;
+    if (a !== null && b !== null) {
+      G[a][b] -= g;
+      G[b][a] -= g;
+    }
+  }
+
+  stampTransient(G) {
+    this.stampDC(G);
+  }
+
+  updateState() {}
+
+  getNodeIndices() {
+    return [this.n1, this.n2];
+  }
+}
+
+export class Capacitor extends Device {
+  constructor(n1, n2, C) {
+    super();
+    this.n1 = n1;
+    this.n2 = n2;
+    this.C = Math.max(1e-15, C);
+    this.vPrev = 0;
+  }
+
+  stampDC() {
+    // Open in DC
+  }
+
+  stampTransient(G, I, solution, dt) {
+    const a = nIndex(this.n1);
+    const b = nIndex(this.n2);
+    const gEq = this.C / dt;
+    const v1 = a !== null ? solution[a] : 0;
+    const v2 = b !== null ? solution[b] : 0;
+    const vCap = v1 - v2;
+    const iEq = gEq * this.vPrev;
+    if (a !== null) {
+      G[a][a] += gEq;
+      I[a] += iEq;
+    }
+    if (b !== null) {
+      G[b][b] += gEq;
+      I[b] -= iEq;
+    }
+    if (a !== null && b !== null) {
+      G[a][b] -= gEq;
+      G[b][a] -= gEq;
+    }
+  }
+
+  updateState(solution) {
+    const a = nIndex(this.n1);
+    const b = nIndex(this.n2);
+    const v1 = a !== null ? solution[a] : 0;
+    const v2 = b !== null ? solution[b] : 0;
+    this.vPrev = v1 - v2;
+  }
+
+  getNodeIndices() {
+    return [this.n1, this.n2];
+  }
+}
+
+export class Inductor extends Device {
+  constructor(n1, n2, L) {
+    super();
+    this.n1 = n1;
+    this.n2 = n2;
+    this.L = Math.max(1e-12, L);
+    this.extraVars = 1; // branch current
+    this.iPrev = 0;
+  }
+
+  stampDC(G, I) {
+    // Treat as short with branch current variable
+    const a = nIndex(this.n1);
+    const b = nIndex(this.n2);
+    const k = this.branchIndex;
+    if (a !== null) {
+      G[a][k] += 1;
+      G[k][a] += 1;
+    }
+    if (b !== null) {
+      G[b][k] -= 1;
+      G[k][b] -= 1;
+    }
+  }
+
+  stampTransient(G, I, solution, dt) {
+    const a = nIndex(this.n1);
+    const b = nIndex(this.n2);
+    const k = this.branchIndex;
+    const rEq = this.L / dt;
+    if (a !== null) {
+      G[a][k] += 1;
+      G[k][a] += 1;
+    }
+    if (b !== null) {
+      G[b][k] -= 1;
+      G[k][b] -= 1;
+    }
+    G[k][k] -= rEq;
+    I[k] -= -rEq * this.iPrev;
+  }
+
+  updateState(solution, dt) {
+    if (this.branchIndex === null) return;
+    this.iPrev = solution[this.branchIndex];
+  }
+
+  getNodeIndices() {
+    return [this.n1, this.n2];
+  }
+}
+
+export class DCVoltageSource extends Device {
+  constructor(nPlus, nMinus, voltage) {
+    super();
+    this.nPlus = nPlus;
+    this.nMinus = nMinus;
+    this.voltage = voltage;
+    this.extraVars = 1;
+  }
+
+  stampDC(G, I) {
+    this.stampVoltage(G, I, this.voltage);
+  }
+
+  stampTransient(G, I) {
+    this.stampVoltage(G, I, this.voltage);
+  }
+
+  stampVoltage(G, I, value) {
+    const a = nIndex(this.nPlus);
+    const b = nIndex(this.nMinus);
+    const k = this.branchIndex;
+    if (a !== null) {
+      G[a][k] += 1;
+      G[k][a] += 1;
+    }
+    if (b !== null) {
+      G[b][k] -= 1;
+      G[k][b] -= 1;
+    }
+    I[k] += value;
+  }
+
+  updateState() {}
+
+  getNodeIndices() {
+    return [this.nPlus, this.nMinus];
+  }
+}
+
+export class ACVoltageSource extends Device {
+  constructor(nPlus, nMinus, params) {
+    super();
+    this.nPlus = nPlus;
+    this.nMinus = nMinus;
+    this.params = params;
+    this.extraVars = 1;
+  }
+
+  valueAt(time) {
+    const { vPeak = 1, freq = 1, phase = 0, offset = 0 } = this.params;
+    return offset + vPeak * Math.sin(2 * Math.PI * freq * time + phase);
+  }
+
+  stampDC(G, I) {
+    this.stampVoltage(G, I, this.params.offset || 0);
+  }
+
+  stampTransient(G, I, _solution, _dt, time) {
+    this.stampVoltage(G, I, this.valueAt(time));
+  }
+
+  stampVoltage(G, I, value) {
+    const a = nIndex(this.nPlus);
+    const b = nIndex(this.nMinus);
+    const k = this.branchIndex;
+    if (a !== null) {
+      G[a][k] += 1;
+      G[k][a] += 1;
+    }
+    if (b !== null) {
+      G[b][k] -= 1;
+      G[k][b] -= 1;
+    }
+    I[k] += value;
+  }
+
+  updateState() {}
+
+  getNodeIndices() {
+    return [this.nPlus, this.nMinus];
+  }
+}
+
+function squareLawCurrent(model, Vgs, Vds) {
+  const { VTO, LAMBDA, kPrime } = model;
+  const Vth = VTO;
+  if (Vgs <= Vth) return { ids: 0, gm: 0, gds: 0 };
+  const Vgt = Vgs - Vth;
+  if (Vds < Vgt) {
+    const ids = kPrime * (Vgt * Vds - (Vds * Vds) / 2) * (1 + LAMBDA * Vds);
+    const gm = kPrime * Vds * (1 + LAMBDA * Vds);
+    const gds = kPrime * (Vgt - Vds) * (1 + 2 * LAMBDA * Vds) / 2 + ids * LAMBDA;
+    return { ids, gm, gds };
+  }
+  const idsSat = 0.5 * kPrime * Vgt * Vgt * (1 + LAMBDA * Vds);
+  const gm = kPrime * Vgt * (1 + LAMBDA * Vds);
+  const gds = idsSat * LAMBDA;
+  return { ids: idsSat, gm, gds };
+}
+
+export class MOSFET extends Device {
+  constructor(type, nd, ng, ns, params = {}) {
+    super();
+    this.type = type; // "NMOS" or "PMOS"
+    this.nd = nd;
+    this.ng = ng;
+    this.ns = ns;
+    const defaults = MOS_MODEL_DEFAULTS[type] || MOS_MODEL_DEFAULTS.NMOS;
+    this.params = { ...defaults, ...params };
+    this.params.K = this.params.kPrime * ((this.params.W || defaults.defaultW) / (this.params.L || defaults.defaultL));
+  }
+
+  stampDC(G, I, solution) {
+    this.stampSmallSignal(G, I, solution, false);
+  }
+
+  stampTransient(G, I, solution) {
+    this.stampSmallSignal(G, I, solution, true);
+  }
+
+  stampSmallSignal(G, I, solution, transient) {
+    const nd = nIndex(this.nd);
+    const ng = nIndex(this.ng);
+    const ns = nIndex(this.ns);
+    const vD = nd !== null ? solution[nd] : 0;
+    const vG = ng !== null ? solution[ng] : 0;
+    const vS = ns !== null ? solution[ns] : 0;
+    const sign = this.type === 'PMOS' ? -1 : 1;
+    const Vgs = sign * (vG - vS);
+    const Vds = sign * (vD - vS);
+    const model = { ...this.params, kPrime: this.params.K };
+    const { ids, gm, gds } = squareLawCurrent(model, Vgs, Vds);
+    const idsSigned = sign * ids;
+
+    // Stamp transconductance: current from drain to source depends on Vg and Vd
+    if (nd !== null) {
+      if (ng !== null) G[nd][ng] += gm * sign;
+      if (ns !== null) G[nd][ns] -= gm * sign + gds;
+      G[nd][nd] += gds;
+      I[nd] -= idsSigned;
+    }
+    if (ns !== null) {
+      if (ng !== null) G[ns][ng] -= gm * sign;
+      if (nd !== null) G[ns][nd] -= gds;
+      G[ns][ns] += gm * sign + gds;
+      I[ns] += idsSigned;
+    }
+  }
+
+  updateState() {}
+
+  getNodeIndices() {
+    return [this.nd, this.ng, this.ns];
+  }
+}

--- a/circuit-sim/src/sim/mosDefaults.js
+++ b/circuit-sim/src/sim/mosDefaults.js
@@ -1,0 +1,48 @@
+/**
+ * Default level-1 MOS process parameters for the educational simulator.
+ * Values are intentionally simple and mirror a SPICE-like model card.
+ */
+export const MOS_MODEL_DEFAULTS = {
+  NMOS: {
+    level: 1,
+    kPrime: 140e-6,
+    VTO: 0.7,
+    GAMMA: 0.45,
+    PHI: 0.9,
+    LAMBDA: 0.1,
+    UO: 350,
+    TOX: 9e-9,
+    NSUB: 9e14,
+    LD: 0.08e-6,
+    CJ: 0.56e-3,
+    CJSW: 0.35e-11,
+    PB: 0.9,
+    MJ: 0.45,
+    MJSW: 0.2,
+    CGDO: 0.4e-9,
+    JS: 1.0e-8,
+    defaultW: 1e-6,
+    defaultL: 1e-6
+  },
+  PMOS: {
+    level: 1,
+    kPrime: 40e-6,
+    VTO: -0.8,
+    GAMMA: 0.4,
+    PHI: 0.8,
+    LAMBDA: 0.2,
+    UO: 100,
+    TOX: 9e-9,
+    NSUB: 5e14,
+    LD: 0.09e-6,
+    CJ: 0.94e-3,
+    CJSW: 0.32e-11,
+    PB: 0.9,
+    MJ: 0.5,
+    MJSW: 0.3,
+    CGDO: 0.3e-9,
+    JS: 0.5e-8,
+    defaultW: 1e-6,
+    defaultL: 1e-6
+  }
+};

--- a/circuit-sim/src/sim/netlist.js
+++ b/circuit-sim/src/sim/netlist.js
@@ -1,0 +1,109 @@
+/**
+ * Netlist representation and compiler that turns a schematic graph into solver-ready objects.
+ */
+import { Solver, createDeviceInstance } from './solver.js';
+
+class UnionFind {
+  constructor() {
+    this.parent = new Map();
+  }
+  find(x) {
+    if (!this.parent.has(x)) this.parent.set(x, x);
+    if (this.parent.get(x) !== x) this.parent.set(x, this.find(this.parent.get(x)));
+    return this.parent.get(x);
+  }
+  union(a, b) {
+    const ra = this.find(a);
+    const rb = this.find(b);
+    if (ra !== rb) this.parent.set(ra, rb);
+  }
+}
+
+export function compileNetlist(schematic) {
+  // Collect pins and wire endpoints
+  const uf = new UnionFind();
+  const points = [];
+  const groundKeys = new Set();
+  schematic.components.forEach((comp) => {
+    comp.pins.forEach((p) => {
+      const key = `${p.x},${p.y}`;
+      points.push(key);
+      uf.find(key);
+      if (comp.kind === 'GND') groundKeys.add(key);
+    });
+  });
+  const wireKeys = new Set();
+  schematic.wires.forEach((w) => {
+    for (let i = 0; i < w.points.length - 1; i++) {
+      const p1 = w.points[i];
+      const p2 = w.points[i + 1];
+      const k1 = `${p1.x},${p1.y}`;
+      const k2 = `${p2.x},${p2.y}`;
+      uf.union(k1, k2);
+    }
+    w.points.forEach((p) => {
+      const k = `${p.x},${p.y}`;
+      points.push(k);
+      uf.find(k);
+      wireKeys.add(k);
+    });
+  });
+
+  // connect pins that sit on wires
+  schematic.components.forEach((comp) => {
+    comp.pins.forEach((p) => {
+      const key = `${p.x},${p.y}`;
+      if (wireKeys.has(key)) uf.union(key, key);
+    });
+  });
+
+  const netMap = new Map();
+  let netIndex = 1; // reserve 0 for GND
+  points.forEach((p) => {
+    const root = uf.find(p);
+    const isGround = groundKeys.has(p);
+    if (isGround) {
+      netMap.set(root, 0);
+      return;
+    }
+    if (!netMap.has(root)) {
+      netMap.set(root, netIndex++);
+    }
+  });
+
+  const nodes = [{ id: 0, name: 'GND' }];
+  for (let i = 1; i < netIndex; i++) nodes.push({ id: i, name: `N${String(i).padStart(3, '0')}` });
+  const pointToNode = new Map();
+  points.forEach((p) => {
+    const root = uf.find(p);
+    pointToNode.set(p, netMap.get(root) || 0);
+  });
+
+  const devices = schematic.components
+    .filter((c) => c.kind !== 'GND')
+    .map((comp) => {
+      const nodesIdx = comp.pins.map((p) => {
+        if (p.netLabel && p.netLabel.toUpperCase() === 'GND') return 0;
+        const key = `${p.x},${p.y}`;
+        if (groundKeys.has(key)) return 0;
+        return netMap.get(uf.find(key)) || 0;
+      });
+      return {
+        type: comp.kind,
+        nodes: nodesIdx,
+        params: comp.params || {}
+      };
+    });
+
+  return { nodes, devices, pointToNode };
+}
+
+export function buildSolverFromNetlist(netlist) {
+  const solver = new Solver();
+  // Add nodes
+  netlist.nodes.slice(1).forEach((n) => solver.addNode(n.name));
+  // Add devices
+  netlist.devices.forEach((d) => solver.addDevice(createDeviceInstance(d)));
+  solver.finalize();
+  return solver;
+}

--- a/circuit-sim/src/sim/solver.js
+++ b/circuit-sim/src/sim/solver.js
@@ -1,0 +1,160 @@
+/**
+ * MNA solver implementing DC operating point and transient analysis with Newton-Raphson.
+ */
+import { Resistor, Capacitor, Inductor, DCVoltageSource, ACVoltageSource, MOSFET } from './devices.js';
+
+function zeros(n, m) {
+  const a = new Array(n);
+  for (let i = 0; i < n; i++) a[i] = new Array(m).fill(0);
+  return a;
+}
+
+function cloneVector(v) {
+  return v.slice();
+}
+
+function norm(v) {
+  return Math.sqrt(v.reduce((acc, x) => acc + x * x, 0));
+}
+
+function gaussianSolve(A, b) {
+  // Dense Gaussian elimination with partial pivoting.
+  const n = b.length;
+  const M = zeros(n, n + 1);
+  for (let i = 0; i < n; i++) {
+    for (let j = 0; j < n; j++) M[i][j] = A[i][j];
+    M[i][n] = b[i];
+  }
+  for (let k = 0; k < n; k++) {
+    // Pivot
+    let pivot = k;
+    for (let i = k + 1; i < n; i++) {
+      if (Math.abs(M[i][k]) > Math.abs(M[pivot][k])) pivot = i;
+    }
+    if (Math.abs(M[pivot][k]) < 1e-15) throw new Error('Matrix singular');
+    [M[k], M[pivot]] = [M[pivot], M[k]];
+    const pivotVal = M[k][k];
+    for (let j = k; j <= n; j++) M[k][j] /= pivotVal;
+    for (let i = 0; i < n; i++) {
+      if (i === k) continue;
+      const factor = M[i][k];
+      for (let j = k; j <= n; j++) M[i][j] -= factor * M[k][j];
+    }
+  }
+  return M.map((row) => row[n]);
+}
+
+export class Solver {
+  constructor() {
+    this.nodes = [{ id: 0, name: 'GND' }];
+    this.devices = [];
+    this.numUnknowns = 0;
+    this.time = 0;
+    this.dt = 1e-6;
+    this.dtMin = 1e-9;
+    this.dtMax = 1e-3;
+    this.maxNewtonIters = 20;
+    this.vTol = 1e-6;
+    this.iTol = 1e-9;
+    this.solution = [];
+  }
+
+  addNode(name) {
+    const id = this.nodes.length;
+    this.nodes.push({ id, name });
+    return id;
+  }
+
+  addDevice(device) {
+    this.devices.push(device);
+  }
+
+  finalize() {
+    const numVoltage = this.nodes.length - 1; // excluding ground
+    let extra = 0;
+    this.devices.forEach((d) => {
+      extra = d.assignExtra(numVoltage + extra);
+    });
+    this.numUnknowns = numVoltage + extra;
+    this.solution = new Array(this.numUnknowns).fill(0);
+  }
+
+  buildSystem(stampFn, time) {
+    const N = this.numUnknowns;
+    const G = zeros(N, N);
+    const I = new Array(N).fill(0);
+    for (const device of this.devices) {
+      stampFn(device, G, I, time);
+    }
+    return { G, I };
+  }
+
+  stampDevice(device, G, I, mode, time) {
+    if (mode === 'dc') {
+      device.stampDC(G, I, this.solution, this.dt, this.time);
+    } else {
+      device.stampTransient(G, I, this.solution, this.dt, time);
+    }
+  }
+
+  solveLinear(G, I) {
+    return gaussianSolve(G, I);
+  }
+
+  solveNewton(mode, time = 0) {
+    let x = cloneVector(this.solution);
+    for (let iter = 0; iter < this.maxNewtonIters; iter++) {
+      const { G, I } = this.buildSystem((d, Gm, Im) => this.stampDevice(d, Gm, Im, mode, time), time);
+      // Build residual: G*x - I = 0
+      const res = new Array(this.numUnknowns).fill(0);
+      for (let i = 0; i < this.numUnknowns; i++) {
+        let sum = 0;
+        for (let j = 0; j < this.numUnknowns; j++) sum += G[i][j] * x[j];
+        res[i] = sum - I[i];
+      }
+      if (norm(res) < this.vTol) {
+        this.solution = x;
+        return { converged: true, iterations: iter + 1 };
+      }
+      // Solve for delta
+      const dx = this.solveLinear(G, I);
+      x = x.map((val, idx) => dx[idx]);
+    }
+    this.solution = x;
+    return { converged: false, iterations: this.maxNewtonIters };
+  }
+
+  runDC() {
+    const result = this.solveNewton('dc');
+    this.devices.forEach((d) => d.updateState(this.solution, this.dt));
+    return result;
+  }
+
+  stepTransient(time) {
+    const { converged } = this.solveNewton('tran', time);
+    this.devices.forEach((d) => d.updateState(this.solution, this.dt));
+    this.time += this.dt;
+    return converged;
+  }
+}
+
+// Factory used by the netlist compiler
+export function createDeviceInstance(def) {
+  const { type, nodes, params } = def;
+  switch (type) {
+    case 'R':
+      return new Resistor(nodes[0], nodes[1], params.R || 1e3);
+    case 'C':
+      return new Capacitor(nodes[0], nodes[1], params.C || 1e-6);
+    case 'L':
+      return new Inductor(nodes[0], nodes[1], params.L || 1e-3);
+    case 'VDC':
+      return new DCVoltageSource(nodes[0], nodes[1], params.V || 0);
+    case 'VAC':
+      return new ACVoltageSource(nodes[0], nodes[1], params);
+    case 'MOS':
+      return new MOSFET(params.type || 'NMOS', nodes[0], nodes[1], nodes[2], params);
+    default:
+      throw new Error(`Unknown device type ${type}`);
+  }
+}

--- a/circuit-sim/src/ui/panels.js
+++ b/circuit-sim/src/ui/panels.js
@@ -1,0 +1,82 @@
+/**
+ * UI panels and property editors.
+ */
+import { parseValue } from './util.js';
+
+const tools = [
+  { id: 'select', label: 'Select' },
+  { id: 'wire', label: 'Wire' },
+  { id: 'R', label: 'Resistor' },
+  { id: 'C', label: 'Capacitor' },
+  { id: 'L', label: 'Inductor' },
+  { id: 'VDC', label: 'DC Source' },
+  { id: 'VAC', label: 'AC Source' },
+  { id: 'MOS', label: 'MOSFET' },
+  { id: 'GND', label: 'Ground' }
+];
+
+export function renderToolbar(el, schematic, onSelect) {
+  el.innerHTML = '';
+  tools.forEach((t) => {
+    const btn = document.createElement('button');
+    btn.textContent = t.label;
+    btn.dataset.tool = t.id;
+    btn.addEventListener('click', () => {
+      document.querySelectorAll('#toolbar button').forEach((b) => b.classList.remove('active'));
+      btn.classList.add('active');
+      schematic.setMode(t.id);
+      onSelect?.(t.id);
+    });
+    if (t.id === 'select') btn.classList.add('active');
+    el.appendChild(btn);
+  });
+}
+
+export function renderSimControls(el, actions) {
+  el.innerHTML = '';
+  const buttons = [
+    { id: 'dc', label: 'DC' },
+    { id: 'run', label: 'Run Tran' },
+    { id: 'stop', label: 'Stop' }
+  ];
+  buttons.forEach((b) => {
+    const btn = document.createElement('button');
+    btn.textContent = b.label;
+    btn.addEventListener('click', () => actions[b.id]());
+    el.appendChild(btn);
+  });
+}
+
+export function updateProperties(container, comp, onChange) {
+  if (!comp) {
+    container.innerHTML = 'Select a component.';
+    return;
+  }
+  const entries = [
+    ['Type', comp.kind],
+    ['ID', comp.id],
+    ['Param A', comp.kind === 'R' ? 'R (Ω)' : comp.kind === 'C' ? 'C (F)' : comp.kind === 'L' ? 'L (H)' : 'Value']
+  ];
+  container.innerHTML = '';
+  entries.forEach(([label, value]) => {
+    const div = document.createElement('div');
+    div.textContent = `${label}: ${value}`;
+    container.appendChild(div);
+  });
+  if (['R', 'C', 'L', 'VDC', 'VAC', 'MOS'].includes(comp.kind)) {
+    const input = document.createElement('input');
+    input.type = 'text';
+    input.value = comp.kind === 'R' ? comp.params.R || 1000 : comp.kind === 'C' ? comp.params.C || 1e-6 : comp.kind === 'L' ? comp.params.L || 1e-3 : comp.params.V || comp.params.vPeak || '';
+    input.addEventListener('change', () => {
+      const val = parseValue(input.value);
+      if (comp.kind === 'R') comp.params.R = val;
+      if (comp.kind === 'C') comp.params.C = val;
+      if (comp.kind === 'L') comp.params.L = val;
+      if (comp.kind === 'VDC') comp.params.V = val;
+      if (comp.kind === 'VAC') comp.params.vPeak = val;
+      if (comp.kind === 'MOS') comp.params.W = val;
+      onChange?.(comp);
+    });
+    container.appendChild(input);
+  }
+}

--- a/circuit-sim/src/ui/schematic.js
+++ b/circuit-sim/src/ui/schematic.js
@@ -1,0 +1,217 @@
+/**
+ * Lightweight schematic editor with grid snapping, Manhattan wiring, and basic selection.
+ */
+import { compileNetlist } from '../sim/netlist.js';
+
+const GRID = 20;
+
+function snap(v) {
+  return Math.round(v / GRID) * GRID;
+}
+
+function colorForVoltage(v) {
+  if (v > 0.05) return '#22d3ee';
+  if (v < -0.05) return '#f87171';
+  return '#9ca3af';
+}
+
+const pinDefs = {
+  R: [{ x: -20, y: 0 }, { x: 20, y: 0 }],
+  C: [{ x: -20, y: 0 }, { x: 20, y: 0 }],
+  L: [{ x: -20, y: 0 }, { x: 20, y: 0 }],
+  VDC: [{ x: -20, y: 0 }, { x: 20, y: 0 }],
+  VAC: [{ x: -20, y: 0 }, { x: 20, y: 0 }],
+  MOS: [{ x: -20, y: 0 }, { x: 0, y: -20 }, { x: 20, y: 0 }],
+  GND: [{ x: 0, y: 0 }]
+};
+
+let idCounter = 1;
+
+export class Schematic {
+  constructor(canvas, logFn) {
+    this.canvas = canvas;
+    this.ctx = canvas.getContext('2d');
+    this.log = logFn;
+    this.components = [];
+    this.wires = [];
+    this.mode = 'select';
+    this.activeTool = null;
+    this.selected = null;
+    this.tempWire = null;
+    this.nodeVoltages = new Map();
+    this.attachEvents();
+    this.draw();
+  }
+
+  attachEvents() {
+    this.canvas.addEventListener('click', (e) => this.onClick(e));
+    this.canvas.addEventListener('mousemove', (e) => this.onMove(e));
+  }
+
+  setMode(mode) {
+    this.mode = mode;
+    this.activeTool = mode;
+  }
+
+  addComponent(kind, pos, params = {}) {
+    const def = pinDefs[kind];
+    if (!def) return;
+    const comp = {
+      id: idCounter++,
+      kind,
+      x: snap(pos.x),
+      y: snap(pos.y),
+      params: { ...params },
+      pins: def.map((p) => ({ x: snap(pos.x + p.x), y: snap(pos.y + p.y) }))
+    };
+    this.components.push(comp);
+    this.selected = comp;
+    this.draw();
+    return comp;
+  }
+
+  addWirePoint(pt) {
+    if (!this.tempWire) this.tempWire = { points: [pt] };
+    this.tempWire.points.push(pt);
+  }
+
+  finishWire(pt) {
+    if (this.tempWire && this.tempWire.points.length > 1) {
+      this.tempWire.points.push(pt);
+      this.wires.push(this.tempWire);
+    }
+    this.tempWire = null;
+  }
+
+  onClick(e) {
+    const rect = this.canvas.getBoundingClientRect();
+    const x = snap(e.clientX - rect.left);
+    const y = snap(e.clientY - rect.top);
+    if (this.mode === 'wire') {
+      if (this.tempWire) {
+        this.finishWire({ x, y });
+      } else {
+        this.addWirePoint({ x, y });
+      }
+      this.draw();
+      return;
+    }
+    if (this.activeTool && this.activeTool !== 'select' && this.activeTool !== 'wire') {
+      this.addComponent(this.activeTool, { x, y });
+      return;
+    }
+    // Selection
+    const hit = this.components.find((c) => Math.abs(c.x - x) < GRID && Math.abs(c.y - y) < GRID);
+    if (hit) this.selected = hit;
+    this.draw();
+  }
+
+  onMove(e) {
+    if (!this.tempWire) return;
+    const rect = this.canvas.getBoundingClientRect();
+    const x = snap(e.clientX - rect.left);
+    const y = snap(e.clientY - rect.top);
+    const pts = [...this.tempWire.points, { x, y }];
+    this.draw(pts);
+  }
+
+  draw(tempWirePts = null) {
+    const ctx = this.ctx;
+    ctx.clearRect(0, 0, this.canvas.width, this.canvas.height);
+    // wires
+    ctx.lineWidth = 3;
+    ctx.strokeStyle = '#9ca3af';
+    const drawWire = (pts) => {
+      ctx.beginPath();
+      pts.forEach((p, idx) => {
+        if (idx === 0) ctx.moveTo(p.x, p.y);
+        else ctx.lineTo(p.x, p.y);
+      });
+      ctx.stroke();
+    };
+    this.wires.forEach((w) => {
+      const color = this.nodeVoltages.get(`${w.points[0].x},${w.points[0].y}`);
+      ctx.strokeStyle = color || '#9ca3af';
+      drawWire(w.points);
+    });
+    if (tempWirePts) {
+      ctx.setLineDash([5, 5]);
+      drawWire(tempWirePts);
+      ctx.setLineDash([]);
+    }
+
+    // components
+    for (const comp of this.components) {
+      ctx.save();
+      ctx.translate(comp.x, comp.y);
+      ctx.strokeStyle = this.selected === comp ? '#22d3ee' : '#e5e7eb';
+      ctx.fillStyle = ctx.strokeStyle;
+      ctx.beginPath();
+      switch (comp.kind) {
+        case 'R':
+          ctx.rect(-20, -6, 40, 12);
+          break;
+        case 'C':
+          ctx.moveTo(-8, -12);
+          ctx.lineTo(-8, 12);
+          ctx.moveTo(8, -12);
+          ctx.lineTo(8, 12);
+          break;
+        case 'L':
+          ctx.arc(-10, 0, 6, 0, Math.PI * 2);
+          ctx.arc(0, 0, 6, 0, Math.PI * 2);
+          ctx.arc(10, 0, 6, 0, Math.PI * 2);
+          break;
+        case 'VDC':
+        case 'VAC':
+          ctx.arc(0, 0, 12, 0, Math.PI * 2);
+          break;
+        case 'MOS':
+          ctx.rect(-12, -18, 24, 36);
+          ctx.moveTo(-12, 0);
+          ctx.lineTo(-22, 0);
+          ctx.moveTo(12, 0);
+          ctx.lineTo(22, 0);
+          ctx.moveTo(0, -18);
+          ctx.lineTo(0, -28);
+          break;
+        case 'GND':
+          ctx.moveTo(-10, 0);
+          ctx.lineTo(10, 0);
+          ctx.moveTo(-6, 4);
+          ctx.lineTo(6, 4);
+          ctx.moveTo(-2, 8);
+          ctx.lineTo(2, 8);
+          break;
+      }
+      ctx.stroke();
+      // pins
+      ctx.fillStyle = '#22d3ee';
+      comp.pins.forEach((p) => {
+        ctx.beginPath();
+        ctx.arc(p.x - comp.x, p.y - comp.y, 3, 0, Math.PI * 2);
+        ctx.fill();
+      });
+      ctx.restore();
+    }
+  }
+
+  updateNodeVoltages(solver) {
+    const map = new Map();
+    if (this.pointToNode) {
+      this.pointToNode.forEach((nodeIdx, key) => {
+        if (nodeIdx === 0) return;
+        const v = solver.solution[nodeIdx - 1] || 0;
+        map.set(key, colorForVoltage(v));
+      });
+    }
+    this.nodeVoltages = map;
+    this.draw();
+  }
+
+  currentNetlist() {
+    const net = compileNetlist(this);
+    this.pointToNode = net.pointToNode;
+    return net;
+  }
+}

--- a/circuit-sim/src/ui/scope.js
+++ b/circuit-sim/src/ui/scope.js
@@ -1,0 +1,92 @@
+/**
+ * Simple two-channel oscilloscope drawing utility.
+ */
+import { formatEngineering } from './util.js';
+
+class RingBuffer {
+  constructor(size) {
+    this.size = size;
+    this.data = new Array(size).fill([0, 0]);
+    this.index = 0;
+    this.count = 0;
+  }
+  push(point) {
+    this.data[this.index] = point;
+    this.index = (this.index + 1) % this.size;
+    this.count = Math.min(this.count + 1, this.size);
+  }
+  values() {
+    if (this.count < this.size) return this.data.slice(0, this.count);
+    return [...this.data.slice(this.index), ...this.data.slice(0, this.index)];
+  }
+}
+
+export class Scope {
+  constructor(canvas) {
+    this.canvas = canvas;
+    this.ctx = canvas.getContext('2d');
+    this.buffers = { ch1: new RingBuffer(1024), ch2: new RingBuffer(1024) };
+    this.vDiv = 1;
+    this.tDiv = 1e-3;
+    this.ch1Node = null;
+    this.ch2Node = null;
+  }
+
+  setNodes(n1, n2) {
+    this.ch1Node = n1;
+    this.ch2Node = n2;
+  }
+
+  setScales({ vDiv, tDiv }) {
+    if (vDiv) this.vDiv = vDiv;
+    if (tDiv) this.tDiv = tDiv;
+  }
+
+  sample(time, v1, v2) {
+    this.buffers.ch1.push([time, v1]);
+    this.buffers.ch2.push([time, v2]);
+  }
+
+  draw() {
+    const ctx = this.ctx;
+    const { width, height } = this.canvas;
+    ctx.fillStyle = '#050912';
+    ctx.fillRect(0, 0, width, height);
+    ctx.strokeStyle = '#1f2937';
+    ctx.lineWidth = 1;
+    for (let i = 0; i < 10; i++) {
+      const x = (i / 10) * width;
+      const y = (i / 10) * height;
+      ctx.beginPath();
+      ctx.moveTo(x, 0);
+      ctx.lineTo(x, height);
+      ctx.moveTo(0, y);
+      ctx.lineTo(width, y);
+      ctx.stroke();
+    }
+
+    const drawWave = (data, color) => {
+      if (data.length < 2) return;
+      const span = this.tDiv * 10;
+      const tMax = data[data.length - 1][0];
+      const tMin = tMax - span;
+      ctx.strokeStyle = color;
+      ctx.beginPath();
+      data.forEach(([t, v], idx) => {
+        const x = ((t - tMin) / span) * width;
+        const y = height / 2 - (v / (this.vDiv * 5)) * height / 2;
+        if (idx === 0) ctx.moveTo(x, y);
+        else ctx.lineTo(x, y);
+      });
+      ctx.stroke();
+    };
+
+    drawWave(this.buffers.ch1.values(), '#fbbf24');
+    drawWave(this.buffers.ch2.values(), '#22d3ee');
+
+    ctx.fillStyle = '#e5e7eb';
+    ctx.font = '12px Inter';
+    ctx.fillText(`CH1 ${formatEngineering(this.vDiv)} V/div`, 10, 16);
+    ctx.fillText(`Time ${formatEngineering(this.tDiv)} s/div`, 10, 32);
+  }
+}

--- a/circuit-sim/src/ui/util.js
+++ b/circuit-sim/src/ui/util.js
@@ -1,0 +1,25 @@
+/** Utility helpers for UI. */
+export function parseValue(str) {
+  const s = String(str).trim();
+  const match = s.match(/([0-9.eE+-]+)\s*([kKmMuUnNpP]?)/);
+  if (!match) return parseFloat(s) || 0;
+  const value = parseFloat(match[1]);
+  const suffix = match[2].toLowerCase();
+  const map = {
+    k: 1e3,
+    m: 1e-3,
+    u: 1e-6,
+    n: 1e-9,
+    p: 1e-12
+  };
+  return value * (map[suffix] || 1);
+}
+
+export function formatEngineering(v) {
+  if (Math.abs(v) >= 1e3) return `${(v / 1e3).toFixed(2)}k`;
+  if (Math.abs(v) >= 1) return v.toFixed(2);
+  if (Math.abs(v) >= 1e-3) return `${(v * 1e3).toFixed(2)}m`;
+  if (Math.abs(v) >= 1e-6) return `${(v * 1e6).toFixed(2)}u`;
+  if (Math.abs(v) >= 1e-9) return `${(v * 1e9).toFixed(2)}n`;
+  return v.toExponential(2);
+}

--- a/circuit-sim/style.css
+++ b/circuit-sim/style.css
@@ -1,0 +1,140 @@
+:root {
+  --bg: #0f172a;
+  --panel: #111827;
+  --accent: #22d3ee;
+  --text: #e5e7eb;
+  --muted: #94a3b8;
+  --grid: rgba(148, 163, 184, 0.2);
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  font-family: 'Inter', system-ui, -apple-system, sans-serif;
+  background: var(--bg);
+  color: var(--text);
+  display: flex;
+  flex-direction: column;
+  min-height: 100vh;
+}
+
+header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 12px 20px;
+  background: #0b1222;
+  border-bottom: 1px solid #1f2937;
+}
+
+header h1 {
+  margin: 0;
+  font-size: 1.1rem;
+}
+
+.nav-links {
+  display: flex;
+  gap: 10px;
+}
+
+.nav-links a {
+  padding: 8px 12px;
+  border-radius: 6px;
+  text-decoration: none;
+  color: var(--text);
+  background: #1f2937;
+}
+
+main {
+  flex: 1;
+  display: grid;
+  grid-template-columns: 2fr 1fr;
+  gap: 12px;
+  padding: 12px;
+}
+
+.canvas-wrapper {
+  position: relative;
+  background: #0b1222;
+  border: 1px solid #1f2937;
+  border-radius: 8px;
+  overflow: hidden;
+}
+
+#schematic {
+  width: 100%;
+  height: 500px;
+  background: radial-gradient(var(--grid) 1px, transparent 0);
+  background-size: 20px 20px;
+  cursor: crosshair;
+}
+
+.sidebar {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.panel {
+  background: var(--panel);
+  border: 1px solid #1f2937;
+  border-radius: 8px;
+  padding: 12px;
+}
+
+.toolbar {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
+  margin-bottom: 8px;
+}
+
+.toolbar button, .panel button, .panel select, .panel input {
+  background: #1f2937;
+  border: 1px solid #334155;
+  color: var(--text);
+  border-radius: 6px;
+  padding: 6px 10px;
+  font-size: 0.9rem;
+}
+
+.toolbar button.active {
+  background: var(--accent);
+  color: #0b1222;
+}
+
+#scope {
+  width: 100%;
+  height: 220px;
+  background: #050912;
+  border-radius: 6px;
+}
+
+.log {
+  background: #0b1222;
+  color: var(--muted);
+  font-family: 'Fira Code', monospace;
+  font-size: 0.85rem;
+  height: 120px;
+  overflow: auto;
+  padding: 8px;
+  border-radius: 6px;
+  border: 1px solid #1f2937;
+}
+
+.property-grid {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 6px;
+  margin-top: 8px;
+}
+
+.canvas-label {
+  position: absolute;
+  pointer-events: none;
+  color: var(--text);
+  font-size: 10px;
+}

--- a/index.html
+++ b/index.html
@@ -63,6 +63,7 @@
             <li><a class="nav-pill" href="ml-game.html">Transformer Lab</a></li>
             <li><a class="nav-pill" href="ml-playground.html">ML Playground</a></li>
             <li><a class="nav-pill" href="endless-depths.html">Endless Depths</a></li>
+            <li><a class="nav-pill" href="circuit-sim/index.html">Circuit Lab</a></li>
           </ul>
           <div class="nav-actions">
             <button class="edit-toggle" type="button" aria-pressed="false" hidden>Edit mode</button>


### PR DESCRIPTION
## Summary
- add a new Circuit Lab tab linking to a standalone browser-based analog simulator
- implement schematic editor, MNA solver, device models, oscilloscope, and UI panels in vanilla JS modules
- include default RC example, styling, and logging for DC and transient runs

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6924de6ca00c8327ade1fae8fec8b125)