### PR TITLE
Scope circuit lab embed and init on mount

### DIFF
--- a/circuit-sim/index.html
+++ b/circuit-sim/index.html
@@ -13,51 +13,53 @@
     <link rel="stylesheet" href="style.css" />
   </head>
   <body>
-    <header>
-      <h1>Analog Circuit Lab</h1>
-      <nav class="nav-links">
-        <a href="../index.html">Home</a>
-        <a href="https://github.com/kaminglui" target="_blank" rel="noreferrer">GitHub</a>
-      </nav>
-    </header>
-    <main>
-      <div class="canvas-wrapper">
-        <div class="toolbar" id="toolbar"></div>
-        <canvas id="schematic" width="900" height="500" aria-label="Schematic canvas"></canvas>
-      </div>
-      <div class="sidebar">
-        <section class="panel" id="sim-panel">
-          <h3>Simulation</h3>
-          <div class="toolbar" id="sim-controls"></div>
-          <div class="property-grid">
-            <label>Time/Div</label>
-            <input type="number" id="time-div" value="1e-3" step="1e-3" />
-            <label>dt</label>
-            <input type="number" id="dt" value="1e-4" step="1e-4" />
-          </div>
-        </section>
-        <section class="panel">
-          <h3>Oscilloscope</h3>
-          <canvas id="scope" width="420" height="220"></canvas>
-          <div class="property-grid">
-            <label>CH1 Node</label>
-            <select id="ch1-node"></select>
-            <label>CH2 Node</label>
-            <select id="ch2-node"></select>
-            <label>Volts/Div</label>
-            <input type="number" id="v-div" value="1" step="0.5" />
-          </div>
-        </section>
-        <section class="panel" id="properties">
-          <h3>Properties</h3>
-          <div id="prop-content">Select a component.</div>
-        </section>
-        <section class="panel">
-          <h3>Log</h3>
-          <div class="log" id="log"></div>
-        </section>
-      </div>
-    </main>
+    <div class="circuit-lab" id="circuit-lab">
+      <header>
+        <h1>Analog Circuit Lab</h1>
+        <nav class="nav-links">
+          <a href="../index.html">Home</a>
+          <a href="https://github.com/kaminglui" target="_blank" rel="noreferrer">GitHub</a>
+        </nav>
+      </header>
+      <main>
+        <div class="canvas-wrapper">
+          <div class="toolbar" id="toolbar"></div>
+          <canvas id="schematic" width="900" height="500" aria-label="Schematic canvas"></canvas>
+        </div>
+        <div class="sidebar">
+          <section class="panel" id="sim-panel">
+            <h3>Simulation</h3>
+            <div class="toolbar" id="sim-controls"></div>
+            <div class="property-grid">
+              <label>Time/Div</label>
+              <input type="number" id="time-div" value="1e-3" step="1e-3" />
+              <label>dt</label>
+              <input type="number" id="dt" value="1e-4" step="1e-4" />
+            </div>
+          </section>
+          <section class="panel">
+            <h3>Oscilloscope</h3>
+            <canvas id="scope" width="420" height="220"></canvas>
+            <div class="property-grid">
+              <label>CH1 Node</label>
+              <select id="ch1-node"></select>
+              <label>CH2 Node</label>
+              <select id="ch2-node"></select>
+              <label>Volts/Div</label>
+              <input type="number" id="v-div" value="1" step="0.5" />
+            </div>
+          </section>
+          <section class="panel" id="properties">
+            <h3>Properties</h3>
+            <div id="prop-content">Select a component.</div>
+          </section>
+          <section class="panel">
+            <h3>Log</h3>
+            <div class="log" id="log"></div>
+          </section>
+        </div>
+      </main>
+    </div>
     <script type="module" src="./src/main.js"></script>
   </body>
 </html>

--- a/circuit-sim/style.css
+++ b/circuit-sim/style.css
@@ -1,4 +1,4 @@
-:root {
+.circuit-lab {
   --bg: #0f172a;
   --panel: #111827;
   --accent: #22d3ee;
@@ -7,11 +7,12 @@
   --grid: rgba(148, 163, 184, 0.2);
 }
 
-* {
+.circuit-lab,
+.circuit-lab * {
   box-sizing: border-box;
 }
 
-body {
+.circuit-lab {
   margin: 0;
   font-family: 'Inter', system-ui, -apple-system, sans-serif;
   background: var(--bg);
@@ -21,7 +22,7 @@ body {
   min-height: 100vh;
 }
 
-header {
+.circuit-lab header {
   display: flex;
   align-items: center;
   justify-content: space-between;
@@ -30,17 +31,17 @@ header {
   border-bottom: 1px solid #1f2937;
 }
 
-header h1 {
+.circuit-lab header h1 {
   margin: 0;
   font-size: 1.1rem;
 }
 
-.nav-links {
+.circuit-lab .nav-links {
   display: flex;
   gap: 10px;
 }
 
-.nav-links a {
+.circuit-lab .nav-links a {
   padding: 8px 12px;
   border-radius: 6px;
   text-decoration: none;
@@ -48,7 +49,7 @@ header h1 {
   background: #1f2937;
 }
 
-main {
+.circuit-lab main {
   flex: 1;
   display: grid;
   grid-template-columns: 2fr 1fr;
@@ -56,7 +57,7 @@ main {
   padding: 12px;
 }
 
-.canvas-wrapper {
+.circuit-lab .canvas-wrapper {
   position: relative;
   background: #0b1222;
   border: 1px solid #1f2937;
@@ -64,7 +65,7 @@ main {
   overflow: hidden;
 }
 
-#schematic {
+.circuit-lab #schematic {
   width: 100%;
   height: 500px;
   background: radial-gradient(var(--grid) 1px, transparent 0);
@@ -72,27 +73,30 @@ main {
   cursor: crosshair;
 }
 
-.sidebar {
+.circuit-lab .sidebar {
   display: flex;
   flex-direction: column;
   gap: 12px;
 }
 
-.panel {
+.circuit-lab .panel {
   background: var(--panel);
   border: 1px solid #1f2937;
   border-radius: 8px;
   padding: 12px;
 }
 
-.toolbar {
+.circuit-lab .toolbar {
   display: flex;
   flex-wrap: wrap;
   gap: 6px;
   margin-bottom: 8px;
 }
 
-.toolbar button, .panel button, .panel select, .panel input {
+.circuit-lab .toolbar button,
+.circuit-lab .panel button,
+.circuit-lab .panel select,
+.circuit-lab .panel input {
   background: #1f2937;
   border: 1px solid #334155;
   color: var(--text);
@@ -101,19 +105,19 @@ main {
   font-size: 0.9rem;
 }
 
-.toolbar button.active {
+.circuit-lab .toolbar button.active {
   background: var(--accent);
   color: #0b1222;
 }
 
-#scope {
+.circuit-lab #scope {
   width: 100%;
   height: 220px;
   background: #050912;
   border-radius: 6px;
 }
 
-.log {
+.circuit-lab .log {
   background: #0b1222;
   color: var(--muted);
   font-family: 'Fira Code', monospace;
@@ -125,14 +129,14 @@ main {
   border: 1px solid #1f2937;
 }
 
-.property-grid {
+.circuit-lab .property-grid {
   display: grid;
   grid-template-columns: 1fr 1fr;
   gap: 6px;
   margin-top: 8px;
 }
 
-.canvas-label {
+.circuit-lab .canvas-label {
   position: absolute;
   pointer-events: none;
   color: var(--text);


### PR DESCRIPTION
## Summary
- Wrap the analog circuit lab markup in a dedicated container so it can be embedded without affecting surrounding pages.
- Scope the lab stylesheet to the new container to keep styles consistent while preventing bleed-over into the host site.
- Defer simulator initialization until required DOM nodes exist and expose a manual init hook for tab-based mounts.

## Testing
- node --check circuit-sim/src/main.js


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6924faf0837c8327b77c2f2b6291251f)